### PR TITLE
feat: 프론트 수정 요청 구현 — 자산/플롯/영상/프로젝트 API 개선 (Dev_CCL → Development)

### DIFF
--- a/docs/planning/프론트_수정_요청_구현_완료.md
+++ b/docs/planning/프론트_수정_요청_구현_완료.md
@@ -1,0 +1,423 @@
+# 프론트 수정 요청 — 백엔드 구현 완료 보고서
+
+> 기준 문서: `프론트_수정_요청_구현_플랜.md`
+> 구현 완료일: 2026-03-23
+> 브랜치: `Dev_CCL`
+
+---
+
+## 전체 구현 현황
+
+| # | 항목 | 상태 | 엔드포인트 |
+|---|------|:----:|-----------|
+| 1.1 | 자산 통합 생성 (Multipart) | ✅ 완료 | `POST /api/projects/{projectId}/{assetType}` |
+| 1.2 | 자산 개별 삭제 | ✅ 완료 | `DELETE /api/projects/{projectId}/{assetType}/{assetId}` |
+| 2.1 | AI 스토리보드 생성 | ✅ 완료 | `POST /api/projects/plots/generate` |
+| 2.2 | 프레임 재생성 | ✅ 완료 | `POST /api/projects/plots/frames/regenerate` |
+| 2.3 | 전체 씬 배치 저장 | ✅ 완료 | `PUT /api/projects/{projectId}/plots/scenes` |
+| 3.1 | 영상 페이지 초기 정보 | ✅ 완료 | `GET /projects/{id}/video-info` |
+| 3.2 | 영상 생성 API 수정 | ✅ 완료 | `POST /api/videos/generate` (기존 확장) |
+| 3.3 | 영상 병합 | ❌ 미구현 | — (구현 복잡도 높음, 별도 협의 필요) |
+| 4.1 | 프로젝트 상세 응답 수정 | ✅ 완료 | `GET /projects/{id}` (기존 확장) |
+
+---
+
+## 상세 구현 내용
+
+---
+
+### 1.1 자산 통합 생성 — `POST /api/projects/{projectId}/{assetType}`
+
+**배경**: 기존 2단계 방식(이미지 임시 생성 → 저장)을 1단계로 통합. Multipart/FormData로 이미지 파일을 직접 수신.
+
+#### 신규/수정 파일
+
+| 파일 | 구분 | 변경 내용 |
+|------|:----:|-----------|
+| `asset/dto/AssetCreateResponse.java` | **신규** | 응답 DTO: id, name, referenceImageUrl, imageUrl, status |
+| `asset/AssetService.java` | 수정 | `createAsset()`, `buildAssetPrompt()` 메서드 추가; StorageService·CharacterService·BackgroundService 의존성 추가 |
+| `asset/AssetController.java` | 수정 | Multipart POST 엔드포인트 추가 |
+| `character/CharacterService.java` | 수정 | `createRaw(projectId, name, referenceImageUrl, artStyle)` 추가 — AssetService에서 호출 |
+| `background/BackgroundService.java` | **신규** | `create()`, `delete()` 메서드 (패키지 `com.estaid.background`) |
+| `content/entity/BackgroundEntity.java` | 수정 | `@Builder`, `@GeneratedValue`, `@PrePersist`, `@PreUpdate` 추가 |
+| `content/repository/BackgroundRepository.java` | 수정 | `findByProjectId()` 메서드 추가 |
+
+#### 처리 흐름
+
+```
+1. referenceImage (MultipartFile)
+        ↓
+2. StorageService.uploadImage(file)
+   → Supabase Storage 업로드 → referenceImageUrl 획득
+        ↓
+3. buildAssetPrompt(name, assetType, style, ratio, quality)
+   → FAL.ai 프롬프트 자동 생성
+        ↓
+4. FalAiService.generateImageSync(referenceImageUrl, prompt)
+   → FAL.ai FLUX Kontext 동기 호출 → aiImageUrl 획득
+        ↓
+5. assetType 분기
+   ├── "characters"  → CharacterService.createRaw() → CharacterEntity 저장
+   └── "backgrounds" → BackgroundService.create()   → BackgroundEntity 저장
+        ↓
+6. Asset 엔티티 저장 (AI 이미지 URL + 타입)
+        ↓
+7. { id, name, referenceImageUrl, imageUrl, status: "COMPLETED" } 반환
+```
+
+#### Request (Multipart/FormData)
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|:----:|------|
+| `name` | String | ✅ | 자산 이름 |
+| `referenceImage` | MultipartFile | ✅ | 참조 이미지 파일 |
+| `style` | String | ✅ | REALISTIC / ANIME / 3D / PAINT / SKETCH |
+| `ratio` | String | - | 16:9 / 9:16 / 1:1 / 4:3 |
+| `quality` | String | - | Standard / High |
+
+#### Response
+
+```json
+{
+  "id": "uuid",
+  "name": "캐릭터명",
+  "referenceImageUrl": "https://supabase.../uploads/xxx.jpg",
+  "imageUrl": "https://fal.ai/.../generated.jpg",
+  "status": "COMPLETED"
+}
+```
+
+---
+
+### 1.2 자산 개별 삭제 — `DELETE /api/projects/{projectId}/{assetType}/{assetId}`
+
+#### 신규/수정 파일
+
+| 파일 | 구분 | 변경 내용 |
+|------|:----:|-----------|
+| `asset/AssetService.java` | 수정 | `deleteAsset(projectId, assetType, assetId)` 추가 |
+| `asset/AssetController.java` | 수정 | DELETE 엔드포인트 추가 |
+
+#### 처리 흐름
+
+```
+assetType = "characters"  → CharacterService.delete(assetId)
+assetType = "backgrounds" → BackgroundService.delete(assetId)
+```
+
+- 잘못된 assetType: `400 Bad Request`
+- 존재하지 않는 assetId: `404 Not Found`
+- 성공: `200 OK`
+
+---
+
+### 2.1 AI 스토리보드 자동 생성 — `POST /api/projects/plots/generate`
+
+**배경**: 기존 `POST /api/plots`에서 엔드포인트·필드·프롬프트 전체 변경. 한 프로젝트당 1회 제한.
+
+#### 신규/수정 파일
+
+| 파일 | 구분 | 변경 내용 |
+|------|:----:|-----------|
+| `plot/dto/PlotGenerateRequest.java` | **신규** | 요청 DTO: projectId, storyDescription, sceneCount, ratio |
+| `plot/dto/SceneDto.java` | 수정 | `backgroundDetail`, `majorStory`, `firstFrameImageUrl`, `lastFrameImageUrl` 추가 |
+| `plot/PlotController.java` | 수정 | 신규 엔드포인트 추가, 기존 API 하위 호환 유지 |
+| `plot/PlotService.java` | 수정 | `generate()` 추가 (1회 제한 로직 포함) |
+| `common/service/ClaudeService.java` | 수정 | 프롬프트 수정: composition Enum 10가지 강제, majorStory, backgroundDetail 추가 |
+
+#### Request
+
+```json
+{
+  "projectId": "uuid",
+  "storyDescription": "전체 줄거리 텍스트",
+  "sceneCount": 4,
+  "ratio": "16:9"
+}
+```
+
+#### Response (SceneDto 주요 필드)
+
+```json
+{
+  "sceneNumber": 1,
+  "title": "숲속의 조우",
+  "composition": "WIDE_SHOT",
+  "background": "어두운 숲",
+  "backgroundDetail": "Dense pine forest with moonlight filtering through the mist",
+  "lighting": "Cinematic moonlight, cold blue tone",
+  "majorStory": "주인공이 숲속에서 낯선 그림자와 마주친다.",
+  "firstFramePrompt": "...(영어 프롬프트)...",
+  "firstFrameImageUrl": null,
+  "lastFramePrompt": "...(영어 프롬프트)...",
+  "lastFrameImageUrl": null
+}
+```
+
+> **주의**: `firstFrameImageUrl` / `lastFrameImageUrl`은 생성 직후 `null`. `2.2 프레임 재생성 API`로 개별 생성.
+
+#### composition 허용값 (10가지)
+
+`EXTREME_CLOSEUP` / `HIGH_ANGLE` / `LOW_ANGLE` / `MEDIUM_SHOT` / `OVER_THE_SHOULDER` /
+`TWO_SHOT` / `WIDE_SHOT` / `BIRD_EYE_VIEW` / `CLOSEUP` / `DUTCH_ANGLE`
+
+---
+
+### 2.2 프레임 이미지 재생성 — `POST /api/projects/plots/frames/regenerate`
+
+#### 신규/수정 파일
+
+| 파일 | 구분 | 변경 내용 |
+|------|:----:|-----------|
+| `plot/dto/FrameRegenerateRequest.java` | **신규** | 요청 DTO: projectId, sceneNumber, firstOrLast, prompt |
+| `plot/dto/FrameRegenerateResponse.java` | **신규** | 응답 DTO: imageUrl |
+| `plot/PlotController.java` | 수정 | 엔드포인트 추가 |
+| `plot/PlotService.java` | 수정 | `regenerateFrame()` 추가 |
+
+#### Request / Response
+
+```json
+// Request
+{
+  "projectId": "uuid",
+  "sceneNumber": 1,
+  "firstOrLast": "FIRST",
+  "prompt": "수정된 영어 프롬프트"
+}
+
+// Response
+{
+  "imageUrl": "https://fal.ai/.../generated.jpg"
+}
+```
+
+#### 처리 흐름
+
+```
+1. projectId → Plot 조회
+2. sceneNumber로 SceneDto 추출
+3. FalAiService.generateImageSync(null, prompt) → 새 이미지 URL 생성
+4. SceneDto.firstFrameImageUrl 또는 lastFrameImageUrl 업데이트
+5. scenesJson 재직렬화 → Plot DB 저장
+6. imageUrl 반환
+```
+
+---
+
+### 2.3 전체 씬 배치 저장 — `PUT /api/projects/{projectId}/plots/scenes`
+
+**배경**: 씬 만들기 페이지에서 "다음" 버튼 클릭 시 전체 씬을 한 번에 저장.
+
+#### 신규/수정 파일
+
+| 파일 | 구분 | 변경 내용 |
+|------|:----:|-----------|
+| `plot/dto/SceneBatchSaveRequest.java` | **신규** | 요청 DTO: `List<SceneDto> scenes` |
+| `plot/PlotController.java` | 수정 | 엔드포인트 추가 |
+| `plot/PlotService.java` | 수정 | `saveScenesBatch()` 추가 |
+
+#### Request
+
+```json
+{
+  "scenes": [
+    {
+      "sceneNumber": 1,
+      "title": "숲속의 조우",
+      "composition": "WIDE_SHOT",
+      "majorStory": "주인공이 그림자와 마주친다.",
+      "firstFrameImageUrl": "https://...",
+      "lastFrameImageUrl": "https://..."
+    }
+  ]
+}
+```
+
+- 기존 `scenesJson`을 요청 데이터로 **완전 교체**
+- 성공: `200 OK` (body 없음)
+
+---
+
+### 3.1 영상 페이지 초기 정보 — `GET /projects/{id}/video-info`
+
+**배경**: 영상 생성 페이지 진입 시 씬별 프레임 URL과 통합 프롬프트를 한 번에 제공.
+
+#### 신규/수정 파일
+
+| 파일 | 구분 | 변경 내용 |
+|------|:----:|-----------|
+| `content/dto/VideoSceneInfoResponse.java` | **신규** | 씬별 정보 record: sceneNumber, title, firstFrameUrl, lastFrameUrl, combinedPrompt |
+| `content/dto/VideoPageInitResponse.java` | **신규** | 최상위 응답 record: projectId, scenes |
+| `content/service/ContentQueryService.java` | 수정 | `getVideoPageInfo()`, `parseScenes()`, `buildCombinedPrompt()` 추가; ObjectMapper·AssetRepository 주입 |
+| `content/controller/ProjectQueryController.java` | 수정 | 엔드포인트 추가 |
+
+#### Response
+
+```json
+{
+  "projectId": "uuid",
+  "scenes": [
+    {
+      "sceneNumber": 1,
+      "title": "숲속의 조우",
+      "firstFrameUrl": "https://...",
+      "lastFrameUrl": "https://...",
+      "combinedPrompt": "A slow cinematic dolly-in through a dark forest..."
+    }
+  ]
+}
+```
+
+#### 데이터 탐색 우선순위
+
+| 필드 | 1순위 | 2순위 (폴백) |
+|------|-------|------------|
+| `firstFrameUrl` | `SceneDto.firstFrameImageUrl` | Image 테이블 FIRST 프레임 |
+| `lastFrameUrl` | `SceneDto.lastFrameImageUrl` | Image 테이블 LAST 프레임 |
+| `combinedPrompt` | `Video.videoPrompt` (기존 영상 있을 때) | `firstFramePrompt + " " + lastFramePrompt` |
+
+---
+
+### 3.2 영상 생성 API 수정 — `POST /api/videos/generate`
+
+**배경**: 기존 `plotId` + `firstImageId` + `lastImageId` 방식 외에 `projectId` + `sceneNumber` + `prompt` 신규 방식 추가.
+
+#### 신규/수정 파일
+
+| 파일 | 구분 | 변경 내용 |
+|------|:----:|-----------|
+| `video/dto/VideoGenerateRequest.java` | 수정 | `projectId`, `prompt` 필드 추가; 기존 필드 optional로 변경 |
+| `video/dto/VideoResponse.java` | 수정 | `thumbnail` 필드 추가; `from(video, thumbnail)` 오버로드 추가 |
+| `video/VideoService.java` | 수정 | projectId 기반 플롯 조회, 사용자 프롬프트 우선 사용, SceneDto URL 사용 로직 추가; `getMainStory()` → `getMajorStory()` 버그 수정 |
+
+#### 방식 A (신규 — projectId 기반)
+
+```json
+// Request
+{
+  "projectId": "uuid",
+  "sceneNumber": 1,
+  "prompt": "A slow cinematic dolly-in through a dark forest..."
+}
+
+// Response (추가된 필드)
+{
+  "videoId": "uuid",
+  "status": "PENDING",
+  "thumbnail": "https://... (첫 프레임 이미지 URL)",
+  ...
+}
+```
+
+- `projectId` → 해당 프로젝트의 첫 번째 플롯 자동 조회
+- `SceneDto.firstFrameImageUrl` / `lastFrameImageUrl` → FAL.ai 입력 이미지로 사용
+- `prompt` → Claude 자동 생성 없이 직접 사용
+- `thumbnail` = `firstFrameImageUrl` (Video 엔티티에 별도 컬럼 없음)
+
+#### 방식 B (기존 — plotId 기반, 하위 호환)
+
+```json
+{
+  "plotId": "uuid",
+  "sceneNumber": 1,
+  "firstImageId": "uuid",
+  "lastImageId": "uuid"
+}
+```
+
+- Image 엔티티 직접 참조 (기존 방식 유지)
+- Claude API로 영상 프롬프트 자동 생성
+
+---
+
+### 4.1 프로젝트 상세 응답 수정 — `GET /projects/{id}`
+
+**배경**: 씬에 title·thumbnail 추가, 에셋(캐릭터·배경 이미지) 목록 추가.
+
+#### 신규/수정 파일
+
+| 파일 | 구분 | 변경 내용 |
+|------|:----:|-----------|
+| `content/dto/AssetItemResponse.java` | **신규** | 에셋 요약 record: assetId, type, imageUrl, prompt |
+| `content/dto/ProjectSceneDetailResponse.java` | 수정 | `sceneTitle`, `thumbnail` 필드 추가 |
+| `content/dto/ProjectDetailResponse.java` | 수정 | `List<AssetItemResponse> assets` 필드 추가 |
+| `content/service/ContentQueryService.java` | 수정 | `getProjectDetail()` — sceneTitle, thumbnail, assets 조회 로직 추가 |
+
+#### Response (변경된 부분)
+
+```json
+{
+  "projectId": "uuid",
+  "title": "내 작품",
+  "scenes": [
+    {
+      "plotId": "uuid",
+      "plotTitle": "플롯 제목",
+      "sceneNumber": 1,
+      "sceneTitle": "숲속의 조우",        ← 신규
+      "thumbnail": "https://...",         ← 신규
+      "images": [...],
+      "video": {...}
+    }
+  ],
+  "assets": [                             ← 신규
+    {
+      "assetId": "uuid",
+      "type": "CHARACTER",
+      "imageUrl": "https://...",
+      "prompt": "character portrait of..."
+    }
+  ]
+}
+```
+
+#### thumbnail 탐색 우선순위
+
+1. `SceneDto.firstFrameImageUrl` (scenesJson에서 파싱)
+2. Image 테이블의 `frameType = "FIRST"` 이미지 URL
+3. 없으면 `null`
+
+---
+
+## 기존 API 하위 호환 유지 목록
+
+변경하지 않은 기존 API — 기존 프론트엔드 코드가 그대로 동작한다.
+
+| 엔드포인트 | 설명 |
+|-----------|------|
+| `POST /api/plots` | 플롯 생성 (구 방식) |
+| `GET /api/plots?projectId={id}` | 플롯 목록 조회 |
+| `GET /api/plots/{plotId}` | 플롯 단건 조회 |
+| `PUT /api/plots/{plotId}/scenes/{sceneNumber}` | 씬 단건 수정 |
+| `DELETE /api/plots/{plotId}` | 플롯 삭제 |
+| `POST /api/characters/generate` | 캐릭터 이미지 임시 생성 |
+| `POST /api/backgrounds/generate` | 배경 이미지 임시 생성 |
+| `POST /api/projects/{projectId}/assets` | 자산 확정 저장 |
+| `GET /api/projects/{projectId}/assets` | 자산 목록 조회 |
+| `POST /api/videos/generate` | 영상 생성 (방식 B 유지) |
+
+---
+
+## DB 변경 사항
+
+**DDL 변경 없음** — `schema.sql` 수정하지 않음.
+
+| 테이블 | 변경 여부 | 비고 |
+|--------|:--------:|------|
+| `characters` | ❌ | 기존 그대로 |
+| `backgrounds` | ❌ | 기존 그대로 |
+| `assets` | ❌ | 기존 그대로 |
+| `plots.scenes_json` | ⚠️ 내용 변경 | JSON 컬럼 변경 없음, 저장되는 필드명 변경 (`mainStory` → `majorStory`, `backgroundDetail` 추가 등) |
+| `videos` | ❌ | thumbnail은 응답 DTO에서만 처리, 컬럼 추가 없음 |
+| `images` | ❌ | 기존 그대로 |
+
+---
+
+## 프론트 협의 필요 사항
+
+| 항목 | 내용 |
+|------|------|
+| `firstFrameImageUrl` / `lastFrameImageUrl` | 플롯 생성 직후 `null` 반환 → `POST /api/projects/plots/frames/regenerate`로 개별 생성 |
+| 영상 생성 동기/비동기 | FAL.ai 영상 생성은 수분 소요 → PENDING 즉시 반환 후 폴링(`GET /api/videos/{videoId}`) |
+| thumbnail | Video 엔티티에 별도 컬럼 없음 → `firstFrameImageUrl`로 대체하여 응답에 포함 |
+| 병합 (3.3) | 구현 복잡도 높아 미구현 — FFmpeg or 외부 API 별도 협의 필요 |

--- a/docs/planning/프론트_수정_요청_구현_플랜.md
+++ b/docs/planning/프론트_수정_요청_구현_플랜.md
@@ -1,0 +1,574 @@
+# 프론트 수정 요청 사항 — 백엔드 구현 플랜
+
+> 기준 문서: `프론트 수정 요청 구현.pdf`
+> 작성일: 2026-03-23
+> 기준 브랜치: master
+
+---
+
+## 가능 여부 한눈에 보기
+
+| # | 기능 | 가능 여부 | 난이도 | 비고 |
+|---|------|:---------:|:------:|------|
+| 1.1 | 자산 생성 (Multipart 통합) | ✅ 가능 | 중 | BackgroundService 신규 필요 |
+| 1.2 | 자산 삭제 | ✅ 가능 | 하 | 간단 |
+| 2.1 | AI 스토리보드 생성 | ⚠️ 가능 (조건부) | 상 | 이미지 URL 비동기 처리 필요 |
+| 2.2 | 프레임 재생성 | ✅ 가능 | 하 | 기존 FalAiService 재사용 |
+| 2.3 | 전체 씬 배치 저장 | ✅ 가능 | 중 | scenes_json 통째 교체 |
+| 3.1 | 영상 페이지 초기 정보 | ✅ 가능 | 하 | 기존 API 응답 수정 |
+| 3.2 | 영상 생성 | ⚠️ 가능 (조건부) | 중 | thumbnail 별도 처리 필요 |
+| 3.3 | 병합 | ❌ 미구현 | 최상 | 외부 도구 필요 |
+| 4.1 | 프로젝트 상세 | ⚠️ 가능 (조건부) | 중 | 에셋·thumbnail 포함 수정 |
+
+---
+
+## 상세 플랜
+
+---
+
+### 1.1. 자산 생성 (AI Generate) — ✅ 가능
+
+#### 현재 문제
+- 현재 2단계: `POST /api/characters/generate` → `POST /api/projects/{id}/assets`
+- 파일 직접 수신 불가 (JSON URL 방식)
+- `description` 필드 없음
+- Background Controller/Service 없음
+
+#### 신규 엔드포인트
+```
+POST /api/projects/{projectId}/{assetType}
+Content-Type: multipart/form-data
+```
+
+#### Request (Multipart/FormData)
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|:----:|------|
+| `name` | String | ✅ | 자산 이름 |
+| `referenceImage` | MultipartFile | ✅ | 참조 이미지 파일 1개 |
+| `description` | String | - | 자산 설명 |
+| `style` | String | ✅ | REALISTIC / ANIME / 3D / PAINT / SKETCH |
+| `ratio` | String | - | 16:9 / 9:16 / 1:1 / 4:3 |
+| `quality` | String | - | Standard / High |
+
+#### Response
+```json
+{
+  "id": "uuid",
+  "name": "캐릭터명 또는 배경명",
+  "imageUrl": "https://... (FAL.ai 생성 이미지)"
+}
+```
+
+#### 처리 흐름
+```
+1. referenceImage (MultipartFile)
+        ↓
+2. StorageService.uploadImage(file)
+   → Supabase Storage 업로드 → referenceImageUrl 획득
+        ↓
+3. name + description + style로 FAL.ai 프롬프트 생성
+   예) "A character named {name}. {description}. {style} style, high quality"
+        ↓
+4. FalAiService.generateImageSync(referenceImageUrl, prompt)
+   → FAL.ai FLUX Kontext 호출 → imageUrl 획득
+        ↓
+5. assetType 분기
+   ├── characters → Character 엔티티 저장 (name, description, referenceImageUrl, artStyle=style)
+   └── backgrounds → Background 엔티티 저장 (name, description, referenceImageUrl, artStyle=style)
+        ↓
+6. { id: Character/BackgroundId, name, imageUrl } 반환
+```
+
+#### 수정/신규 파일
+| 파일 | 신규/수정 |
+|------|:--------:|
+| `asset/dto/AssetCreateResponse.java` | 신규 |
+| `asset/AssetController.java` — 통합 엔드포인트 추가 | 수정 |
+| `asset/AssetService.java` — `createAsset()` 메서드 추가 | 수정 |
+| `background/BackgroundService.java` | **신규** |
+| `background/BackgroundRepository.java` | 기존 (변경 없음) |
+| `character/CharacterService.java` | 재사용 |
+
+> ⚠️ **주의**: `Character` 엔티티에 `description` 필드가 있지만 `Background` 엔티티도 동일하게 description이 있는지 스키마 확인 필요. `backgrounds` 테이블에는 `description TEXT` 컬럼 있음 → 문제없음.
+
+---
+
+### 1.2. 자산 개별 삭제 (Delete) — ✅ 가능
+
+#### 신규 엔드포인트
+```
+DELETE /api/projects/{projectId}/{assetType}/{assetId}
+```
+
+#### 처리 흐름
+```
+assetType = "characters" → CharacterService.delete(assetId)
+assetType = "backgrounds" → BackgroundService.delete(assetId)
+```
+
+#### Response
+- 성공: `200 OK` `{ "message": "삭제되었습니다." }`
+- 없는 ID: `404 Not Found`
+
+#### 수정 파일
+| 파일 | 신규/수정 |
+|------|:--------:|
+| `asset/AssetController.java` — DELETE 엔드포인트 추가 | 수정 |
+| `asset/AssetService.java` — `deleteAsset()` 추가 | 수정 |
+| `background/BackgroundService.java` — `delete()` | 신규 |
+| `character/CharacterService.java` — `delete()` 이미 있음 | 재사용 |
+
+---
+
+### 2.1. AI 스토리보드 자동 생성 — ⚠️ 가능 (조건부)
+
+#### 현재 문제
+| 항목 | 현재 | 요청 |
+|------|------|------|
+| 엔드포인트 | `POST /api/plots` | `POST /api/projects/plots/generate` |
+| `idea` | idea | storyDescription |
+| `artStyle` | 있음 | 없음 |
+| `characterId` | 있음 | 없음 |
+| `ratio` | 없음 | 있음 |
+| `composition` | String (자유 텍스트) | Enum 10가지 |
+| `mainStory` | mainStory | majorStory |
+| `background` | 배경 묘사 텍스트 | 배경 자산 이름 |
+| `backgroundDetail` | 없음 | AI 생성 배경 상세 |
+| `firstFrameImageUrl` | 없음 | 있음 |
+| `lastFrameImageUrl` | 없음 | 있음 |
+| 중복 생성 제한 | 없음 | 한 프로젝트당 1번 |
+
+#### 신규 엔드포인트
+```
+POST /api/projects/plots/generate
+Content-Type: application/json
+```
+
+#### Request
+```json
+{
+  "projectId": "uuid",
+  "storyDescription": "전체 줄거리 텍스트",
+  "sceneCount": 4,
+  "ratio": "16:9"
+}
+```
+
+#### Response — Scene 객체 (각 씬)
+```json
+{
+  "sceneNumber": 1,
+  "title": "숲속의 조우",
+  "composition": "WIDE_SHOT",
+  "background": "어두운 숲",
+  "backgroundDetail": "울창한 소나무 숲, 달빛이 스며드는 안개",
+  "lighting": "Cinematic moonlight, cold blue tone",
+  "majorStory": "주인공이 숲속에서 낯선 그림자와 마주친다.",
+  "firstFramePrompt": "...(영어 프롬프트)...",
+  "firstFrameImageUrl": null,
+  "lastFramePrompt": "...(영어 프롬프트)...",
+  "lastFrameImageUrl": null
+}
+```
+
+#### ⚠️ firstFrameImageUrl / lastFrameImageUrl 처리 방식
+
+**문제**: 씬 N개 × 2프레임 = 최대 20개 FAL.ai 동기 호출 → 수분 소요.
+
+**권장 방식 (비동기)**:
+1. Claude로 씬 메타데이터 생성 → Plot DB 저장
+2. 각 씬의 firstFramePrompt / lastFramePrompt로 Image 엔티티 PENDING 생성
+3. @Async로 FAL.ai 이미지 생성 백그라운드 실행
+4. 초기 응답에서 `firstFrameImageUrl = null`, `lastFrameImageUrl = null` 반환
+5. 프론트는 **2.2 프레임 재생성** API로 개별 이미지 확인/재생성
+
+> → 프론트에 "처음엔 null로 내려가고, 2.2로 폴링/재생성" 방식 협의 필요
+
+#### ⚠️ 한 프로젝트당 1번 제한
+Plot 생성 전 해당 `projectId`로 이미 Plot이 존재하면 `409 Conflict` 반환.
+
+#### CompositionType Enum (신규)
+```java
+EXTREME_CLOSEUP  // 극도의 클로즈업
+HIGH_ANGLE       // 위에서 아래 부감
+LOW_ANGLE        // 아래에서 위 앙굴
+MEDIUM_SHOT      // 인물 상반신
+OVER_THE_SHOULDER // 어깨 너머
+TWO_SHOT         // 두 명 등장
+WIDE_SHOT        // 넓은 배경
+BIRD_EYE_VIEW    // 수직 부감
+CLOSEUP          // 얼굴 집중
+DUTCH_ANGLE      // 비스듬한 불안정 샷
+```
+
+#### SceneDto 필드 변경
+| 현재 필드 | 변경 후 | 비고 |
+|-----------|---------|------|
+| `composition: String` | `composition: String` (Enum 값 문자열로 저장) | JSON 직렬화 호환 |
+| `background: String` | `background: String` | 배경 자산 이름으로 활용 |
+| (없음) | `backgroundDetail: String` | AI 생성 배경 상세 묘사 |
+| `mainStory: String` | `majorStory: String` | 필드명 변경 |
+| (없음) | `firstFrameImageUrl: String` | 초기 null |
+| (없음) | `lastFrameImageUrl: String` | 초기 null |
+
+> 💡 `composition`은 Enum 타입 대신 **String으로 유지**하되, Claude 프롬프트에서 Enum 값 10가지 중 하나만 출력하도록 강제. 이유: scenes_json에 JSON 직렬화 시 Enum 역직렬화 오류 방지.
+
+#### ClaudeService 프롬프트 수정 내용
+```
+// composition 지시 변경
+"composition": "반드시 아래 10가지 중 하나만 출력:
+EXTREME_CLOSEUP, HIGH_ANGLE, LOW_ANGLE, MEDIUM_SHOT,
+OVER_THE_SHOULDER, TWO_SHOT, WIDE_SHOT,
+BIRD_EYE_VIEW, CLOSEUP, DUTCH_ANGLE"
+
+// 필드명 변경
+"mainStory" → "majorStory"
+
+// 신규 필드 추가 지시
+"background": "1~3단어의 배경 장소 이름 (예: 어두운 숲, 도심 옥상)"
+"backgroundDetail": "배경 상세 묘사 (영어, 이미지 생성 프롬프트용)"
+```
+
+#### 수정/신규 파일
+| 파일 | 신규/수정 |
+|------|:--------:|
+| `plot/dto/PlotGenerateRequest.java` | 신규 |
+| `plot/dto/SceneDto.java` — 필드 추가/변경 | 수정 |
+| `plot/PlotController.java` — 신규 엔드포인트 | 수정 |
+| `plot/PlotService.java` — 생성 로직 | 수정 |
+| `common/service/ClaudeService.java` — 프롬프트 | 수정 |
+
+---
+
+### 2.2. 프레임 재생성 — ✅ 가능
+
+#### 엔드포인트 (신규)
+```
+POST /api/projects/plots/frames/regenerate
+Content-Type: application/json
+```
+
+#### Request
+```json
+{
+  "projectId": "uuid",
+  "sceneNumber": 1,
+  "firstOrLast": "FIRST",
+  "prompt": "수정된 영어 프롬프트"
+}
+```
+
+#### Response
+```json
+{
+  "imageUrl": "https://..."
+}
+```
+
+#### 처리 흐름
+```
+1. projectId로 Plot 조회
+2. 해당 sceneNumber + firstOrLast(FIRST/LAST)로 Image 엔티티 조회
+3. FalAiService.generateImageSync(referenceImageUrl=null, prompt) 호출
+4. Image.imageUrl, Image.prompt 업데이트 → COMPLETED
+5. imageUrl 반환
+```
+
+> 기존 `Image` 엔티티(`FrameType.FIRST` / `FrameType.LAST`)를 그대로 활용.
+> 기존 ImageService/ImageController가 있다면 재사용. 없으면 PlotService 내에 메서드 추가.
+
+#### 수정/신규 파일
+| 파일 | 신규/수정 |
+|------|:--------:|
+| `plot/dto/FrameRegenerateRequest.java` | 신규 |
+| `plot/dto/FrameRegenerateResponse.java` | 신규 |
+| `plot/PlotController.java` | 수정 |
+| `plot/PlotService.java` — `regenerateFrame()` | 수정 |
+
+---
+
+### 2.3. 전체 씬 배치 저장 (다음 버튼) — ✅ 가능
+
+#### 엔드포인트 (신규)
+```
+PUT /api/projects/{projectId}/plots/scenes
+Content-Type: application/json
+```
+
+#### Request
+```json
+{
+  "scenes": [
+    {
+      "sceneNumber": 1,
+      "title": "숲속의 조우",
+      "composition": "WIDE_SHOT",
+      "background": "어두운 숲",
+      "backgroundDetail": "울창한 소나무 숲...",
+      "lighting": "Cinematic moonlight",
+      "majorStory": "주인공이 그림자와 마주친다.",
+      "firstFramePrompt": "...",
+      "firstFrameImageUrl": "https://...",
+      "lastFramePrompt": "...",
+      "lastFrameImageUrl": "https://..."
+    }
+  ]
+}
+```
+
+#### Response
+- `200 OK` 반환, 바디 없음 (res: X)
+
+#### 처리 흐름
+```
+1. projectId로 Plot 조회 (없으면 404)
+2. 요청 scenes 배열로 기존 scenesJson 통째 교체
+3. 각 씬의 firstFrameImageUrl / lastFrameImageUrl로 Image 엔티티 업데이트
+4. Plot DB 저장
+```
+
+#### 수정/신규 파일
+| 파일 | 신규/수정 |
+|------|:--------:|
+| `plot/dto/SceneBatchSaveRequest.java` | 신규 |
+| `plot/PlotController.java` | 수정 |
+| `plot/PlotService.java` — `saveScenesBatch()` | 수정 |
+
+---
+
+### 3.1. 영상 생성 페이지 초기 정보 — ✅ 가능
+
+#### 엔드포인트 (기존 수정)
+```
+GET /api/projects/{projectId}/video-info
+```
+
+#### Response
+```json
+{
+  "scenes": [
+    {
+      "sceneNumber": 1,
+      "title": "숲속의 조우",
+      "firstFrameUrl": "https://...",
+      "lastFrameUrl": "https://...",
+      "combinedPrompt": "A slow cinematic dolly-in..."
+    }
+  ]
+}
+```
+
+#### 처리 흐름
+```
+1. projectId → Plot 조회
+2. SceneDto 목록 파싱
+3. 각 씬 번호로:
+   - Image 테이블에서 FIRST frameType imageUrl → firstFrameUrl
+   - Image 테이블에서 LAST frameType imageUrl → lastFrameUrl
+   - SceneDto의 firstFramePrompt + lastFramePrompt 합산 → combinedPrompt
+4. 응답 구성
+```
+
+> **총합영문프롬프트** = 해당 씬의 firstFramePrompt + " " + lastFramePrompt 또는 Video.videoPrompt (기존 영상이 있으면 사용)
+
+#### 수정/신규 파일
+| 파일 | 신규/수정 |
+|------|:--------:|
+| `content/dto/VideoPageInitResponse.java` | 신규 |
+| `content/controller/ProjectQueryController.java` | 수정 |
+| `content/service/ContentQueryService.java` | 수정 |
+
+---
+
+### 3.2. 영상 생성 — ⚠️ 가능 (조건부)
+
+#### 현재 엔드포인트
+```
+POST /api/videos/generate
+Request: { plotId, sceneNumber }
+Response: VideoResponse (status=PENDING)
+```
+
+#### 요청 변경 사항
+```
+req: projectId, sceneNumber, prompt
+res: videoUrl, thumbnail
+```
+
+#### 현재 vs 요청 비교
+| 항목 | 현재 | 요청 |
+|------|------|------|
+| Request | `plotId`, `sceneNumber` | `projectId`, `sceneNumber`, `prompt` |
+| Response | `VideoResponse` (status=PENDING, videoUrl 나중에) | `videoUrl`, `thumbnail` 즉시 |
+| 처리 방식 | 비동기 (@Async, 폴링) | 즉시 반환? |
+
+#### ⚠️ 문제점 1 — thumbnail
+현재 `Video` 엔티티와 FAL.ai wan-flf2v 응답에 **thumbnail 필드 없음**.
+
+**해결 방안**:
+- FAL.ai wan-flf2v 응답 JSON에 thumbnail 관련 필드가 있는지 확인
+- 없다면 `videoUrl`의 첫 프레임을 썸네일로 사용 (프론트에서 처리) 또는 별도 썸네일 생성 불필요로 협의
+- 임시 방안: `thumbnail = firstFrameImageUrl` (씬의 시작 프레임 이미지를 썸네일로 활용)
+
+#### ⚠️ 문제점 2 — 동기 vs 비동기
+현재 영상 생성은 비동기 (PENDING 반환 → 폴링). FAL.ai wan-flf2v는 수분 소요.
+요청처럼 즉시 videoUrl 반환하려면 **동기 처리** 필요 → 타임아웃 위험.
+
+**권장**: 기존 비동기 유지, 프론트와 협의하여 폴링 방식 채택.
+
+#### 수정 파일
+| 파일 | 신규/수정 |
+|------|:--------:|
+| `video/dto/VideoGenerateRequest.java` — projectId 추가 | 수정 |
+| `video/dto/VideoResponse.java` — thumbnail 필드 추가 (임시: firstFrameImageUrl) | 수정 |
+| `video/VideoController.java` | 수정 |
+| `video/VideoService.java` | 수정 |
+
+---
+
+### 3.3. 병합 — ❌ 현재 미구현
+
+#### 현재 상태
+- `Video.VideoType.MERGED` Enum 값만 정의됨
+- `VideoService`에 병합 메서드 없음
+- `VideoController`에 병합 엔드포인트 없음
+
+#### 구현에 필요한 것
+영상 병합은 단순 URL 연결이 아닌 **실제 동영상 파일 병합** 작업이 필요:
+
+**옵션 A — FFmpeg (서버 직접)**
+- 서버에 FFmpeg 설치 필요
+- 각 씬 videoUrl 다운로드 → FFmpeg concat → Supabase 업로드
+- 구현 복잡도 높음, 서버 리소스 소모
+
+**옵션 B — 외부 API**
+- Cloudinary, Mux 등 동영상 편집 API 활용
+- 추가 비용 발생
+
+**옵션 C — FAL.ai**
+- FAL.ai에 영상 병합 기능 있는지 확인 필요
+
+**현재 판단: 해커톤 기간 내 구현 어려움. 우선순위 낮춤.**
+
+만약 구현한다면:
+```
+POST /api/projects/{projectId}/videos/merge
+req: projectId
+res: videoUrl (최종 병합 영상)
+
+처리: 각 씬 SCENE 영상 URL 수집 → 병합 → Supabase 업로드 → MERGED Video 엔티티 저장
+```
+
+---
+
+### 4.1. 프로젝트 상세 — ⚠️ 가능 (조건부)
+
+#### 현재 응답 구조 vs 요청
+현재 `ContentQueryService.getProjectDetail()`은 씬+이미지+영상 포함. 하지만 부족한 부분 있음.
+
+| 항목 | 현재 포함 | 요청 |
+|------|:--------:|------|
+| 제목 | ✅ | ✅ |
+| 날짜 | ✅ | ✅ |
+| 씬[].sceneNumber | ✅ | ✅ |
+| 씬[].title | ❌ (없음) | ✅ |
+| 씬[].videoUrl | ✅ | ✅ |
+| 씬[].thumbnail | ❌ (없음) | ✅ |
+| 에셋[].imageUrl | ❌ (없음) | ✅ |
+| 에셋[].prompt | ❌ (없음) | ✅ |
+
+#### 변경 내용
+
+**씬 title 추가**: `Video` 엔티티에는 title 없음 → `Plot.scenesJson`에서 해당 sceneNumber의 title 파싱.
+
+**씬 thumbnail 추가**:
+- Video 엔티티에 thumbnail 없음
+- → 해당 씬의 FIRST 프레임 Image.imageUrl을 thumbnail로 활용
+
+**에셋 추가**:
+- `Asset` 테이블 (`assets`) 이미 있음
+- `ProjectDetailResponse`에 `List<AssetItemResponse>` 추가
+- `AssetItemResponse` = `{ imageUrl, prompt }`
+
+#### 수정 파일
+| 파일 | 신규/수정 |
+|------|:--------:|
+| `content/dto/ProjectDetailResponse.java` — 에셋 목록 추가 | 수정 |
+| `content/dto/ProjectSceneDetailResponse.java` — title, thumbnail 추가 | 수정 |
+| `content/dto/AssetItemResponse.java` | 신규 |
+| `content/service/ContentQueryService.java` — 조회 로직 수정 | 수정 |
+
+---
+
+## 구현 순서 (권장)
+
+```
+Step 1. [1.1] BackgroundService 신규 생성
+          → background/BackgroundService.java
+
+Step 2. [1.1] 자산 생성 통합 API
+          → AssetController, AssetService 수정
+          → AssetCreateResponse 신규
+
+Step 3. [1.2] 자산 삭제 API
+          → AssetController, AssetService 수정
+
+Step 4. [2.1] SceneDto 필드 수정
+          → majorStory, backgroundDetail, firstFrameImageUrl, lastFrameImageUrl, composition 정리
+
+Step 5. [2.1] ClaudeService 프롬프트 수정
+          → composition Enum 강제, majorStory, backgroundDetail 추가
+
+Step 6. [2.1] 플롯 생성 API 변경
+          → PlotGenerateRequest 신규
+          → PlotController / PlotService 수정
+          → 프로젝트당 1회 제한 로직
+
+Step 7. [2.2] 프레임 재생성 API
+          → FrameRegenerateRequest/Response 신규
+          → PlotController / PlotService 수정
+
+Step 8. [2.3] 전체 씬 배치 저장 API
+          → SceneBatchSaveRequest 신규
+          → PlotController / PlotService 수정
+
+Step 9. [3.1] 영상 페이지 초기 정보 API
+          → VideoPageInitResponse 신규
+          → ContentQueryService 수정
+
+Step 10. [3.2] 영상 생성 API 수정
+           → VideoGenerateRequest: projectId 추가
+           → VideoResponse: thumbnail 필드 추가 (firstFrameImageUrl 활용)
+
+Step 11. [4.1] 프로젝트 상세 응답 수정
+           → 씬 title, thumbnail 추가
+           → 에셋 목록 추가
+
+Step 12. [3.3] 병합 (시간 여유 있을 때)
+           → 구현 방식 별도 협의 후 진행
+```
+
+---
+
+## DB 변경 여부
+
+| 테이블 | 변경 | 이유 |
+|--------|:----:|------|
+| `characters` | ❌ | 기존 스키마 그대로 |
+| `backgrounds` | ❌ | 기존 스키마 그대로 |
+| `assets` | ❌ | 기존 스키마 그대로 |
+| `plots.scenes_json` | ⚠️ 내용 변경 | majorStory, backgroundDetail 등 필드 추가 (컬럼 추가 아님, JSON 내용 변경) |
+| `videos` | ❌ | thumbnail은 엔티티 필드 추가 없이 응답 DTO에서 처리 |
+| `schema.sql` | ❌ | DDL 수정 없음 |
+
+---
+
+## 프론트 협의 필요 사항
+
+| 항목 | 내용 |
+|------|------|
+| firstFrameImageUrl/lastFrameImageUrl | 플롯 생성 직후 null 반환, 2.2 API로 개별 생성 방식 동의 필요 |
+| 영상 생성 동기/비동기 | 즉시 videoUrl 반환 불가, 폴링 방식 협의 필요 |
+| thumbnail | Video 엔티티에 없음 → 씬의 첫 프레임 이미지 URL로 대체 협의 |
+| 병합 | 구현 복잡도 높음, 해커톤 우선순위 조정 필요 |
+| 총합영문프롬프트 | firstFramePrompt + lastFramePrompt 합산인지 확인 필요 |

--- a/src/main/java/com/estaid/asset/AssetController.java
+++ b/src/main/java/com/estaid/asset/AssetController.java
@@ -1,5 +1,6 @@
 package com.estaid.asset;
 
+import com.estaid.asset.dto.AssetCreateResponse;
 import com.estaid.asset.dto.AssetResponse;
 import com.estaid.asset.dto.AssetSaveRequest;
 import com.estaid.asset.dto.GenerateRequest;
@@ -8,8 +9,10 @@ import com.estaid.common.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -18,11 +21,18 @@ import java.util.List;
  *
  * <p>캐릭터·배경 이미지 임시 생성 및 프로젝트 저장을 담당한다.</p>
  *
+ * <p>기존 API (하위 호환 유지):</p>
  * <ul>
  *   <li>POST /api/characters/generate              - 캐릭터 이미지 임시 생성 (DB 저장 X)</li>
  *   <li>POST /api/backgrounds/generate             - 배경 이미지 임시 생성 (DB 저장 X)</li>
  *   <li>POST /api/projects/{projectId}/assets      - "프로젝트에 사용하기" 확정 저장</li>
  *   <li>GET  /api/projects/{projectId}/assets      - 프로젝트의 Asset 목록 조회</li>
+ * </ul>
+ *
+ * <p>신규 API (통합 생성/삭제):</p>
+ * <ul>
+ *   <li>POST   /api/projects/{projectId}/{assetType}            - 1단계 통합 생성 (Multipart)</li>
+ *   <li>DELETE /api/projects/{projectId}/{assetType}/{assetId}  - 자산 개별 삭제</li>
  * </ul>
  */
 @RestController
@@ -94,5 +104,84 @@ public class AssetController {
     public ResponseEntity<ApiResponse<List<AssetResponse>>> findAllByProject(
             @PathVariable String projectId) {
         return ResponseEntity.ok(ApiResponse.ok(assetService.findAllByProject(projectId)));
+    }
+
+    // ─────────────────────────────────────────
+    // 신규 API: 통합 생성 / 개별 삭제
+    // ─────────────────────────────────────────
+
+    /**
+     * 자산 1단계 통합 생성 (Multipart)
+     *
+     * <p>참조 이미지 업로드 → AI 이미지 생성 → 엔티티 저장을 한 번에 처리한다.
+     * 기존 2단계 방식(generate → save)을 대체하는 신규 API이다.</p>
+     *
+     * <p>assetType 경로 변수:</p>
+     * <ul>
+     *   <li>{@code characters}  - 캐릭터 자산 생성 → CharacterEntity + Asset 저장</li>
+     *   <li>{@code backgrounds} - 배경 자산 생성   → BackgroundEntity + Asset 저장</li>
+     * </ul>
+     *
+     * <p>Multipart 필드:</p>
+     * <ul>
+     *   <li>name           - 자산 이름 (필수)</li>
+     *   <li>referenceImage - 참조 이미지 파일 (필수, image/*)</li>
+     *   <li>style          - 화풍 (필수, 예: REALISTIC, ANIME, 3D, PAINT, SKETCH)</li>
+     *   <li>ratio          - 이미지 비율 (선택, 예: 16:9, 9:16, 1:1, 4:3)</li>
+     *   <li>quality        - 이미지 품질 (선택, 예: Standard, High)</li>
+     * </ul>
+     *
+     * @param projectId      소속 프로젝트 UUID (경로 변수)
+     * @param assetType      자산 유형 ("characters" 또는 "backgrounds", 경로 변수)
+     * @param name           자산 이름 (Multipart 필드, 필수)
+     * @param referenceImage 참조 이미지 파일 (Multipart 파트, 필수)
+     * @param style          화풍 (Multipart 필드, 필수)
+     * @param ratio          이미지 비율 (Multipart 필드, 선택)
+     * @param quality        이미지 품질 (Multipart 필드, 선택)
+     * @return 201 Created + 생성된 자산 정보 (id, name, referenceImageUrl, imageUrl, status)
+     */
+    @PostMapping(value = "/api/projects/{projectId}/{assetType}",
+                 consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<AssetCreateResponse>> createAsset(
+            @PathVariable String projectId,
+            @PathVariable String assetType,
+            @RequestParam("name") String name,
+            @RequestPart("referenceImage") MultipartFile referenceImage,
+            @RequestParam("style") String style,
+            @RequestParam(value = "ratio", required = false) String ratio,
+            @RequestParam(value = "quality", required = false) String quality) {
+
+        AssetCreateResponse response = assetService.createAsset(
+                projectId, assetType, name, referenceImage, style, ratio, quality);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.ok("자산이 생성되었습니다.", response));
+    }
+
+    /**
+     * 자산 개별 삭제
+     *
+     * <p>캐릭터 또는 배경 엔티티를 삭제한다.
+     * assetType에 따라 캐릭터(characterId) 또는 배경(backgroundId)을 삭제한다.</p>
+     *
+     * <p>assetType 경로 변수:</p>
+     * <ul>
+     *   <li>{@code characters}  - CharacterEntity 삭제</li>
+     *   <li>{@code backgrounds} - BackgroundEntity 삭제</li>
+     * </ul>
+     *
+     * @param projectId 소속 프로젝트 UUID (경로 변수)
+     * @param assetType 자산 유형 ("characters" 또는 "backgrounds", 경로 변수)
+     * @param assetId   삭제할 자산 UUID (경로 변수)
+     * @return 200 OK
+     */
+    @DeleteMapping("/api/projects/{projectId}/{assetType}/{assetId}")
+    public ResponseEntity<ApiResponse<Void>> deleteAsset(
+            @PathVariable String projectId,
+            @PathVariable String assetType,
+            @PathVariable String assetId) {
+
+        assetService.deleteAsset(projectId, assetType, assetId);
+        return ResponseEntity.ok(ApiResponse.ok("자산이 삭제되었습니다.", null));
     }
 }

--- a/src/main/java/com/estaid/asset/AssetService.java
+++ b/src/main/java/com/estaid/asset/AssetService.java
@@ -1,11 +1,17 @@
 package com.estaid.asset;
 
+import com.estaid.asset.dto.AssetCreateResponse;
 import com.estaid.asset.dto.AssetResponse;
 import com.estaid.asset.dto.AssetSaveRequest;
 import com.estaid.asset.dto.GenerateRequest;
 import com.estaid.asset.dto.GenerateResponse;
+import com.estaid.background.BackgroundService;
+import com.estaid.character.Character;
+import com.estaid.character.CharacterService;
 import com.estaid.common.exception.BusinessException;
 import com.estaid.common.service.FalAiService;
+import com.estaid.common.service.StorageService;
+import com.estaid.content.entity.BackgroundEntity;
 import com.estaid.project.Project;
 import com.estaid.project.ProjectRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -23,9 +30,11 @@ import java.util.List;
  *
  * <p>주요 기능:</p>
  * <ul>
- *   <li>{@link #generateImage}  - FAL.ai로 이미지 임시 생성 (DB 저장 X)</li>
- *   <li>{@link #saveAsset}      - 생성된 이미지를 프로젝트에 확정 저장</li>
+ *   <li>{@link #generateImage}    - FAL.ai로 이미지 임시 생성 (DB 저장 X)</li>
+ *   <li>{@link #saveAsset}        - 생성된 이미지를 프로젝트에 확정 저장 (기존 API)</li>
  *   <li>{@link #findAllByProject} - 프로젝트의 Asset 목록 조회</li>
+ *   <li>{@link #createAsset}      - 1단계 통합 생성 (Multipart 업로드 → AI 생성 → 저장)</li>
+ *   <li>{@link #deleteAsset}      - 자산 개별 삭제 (characters / backgrounds)</li>
  * </ul>
  */
 @Slf4j
@@ -36,6 +45,15 @@ public class AssetService {
     private final AssetRepository assetRepository;
     private final ProjectRepository projectRepository;
     private final FalAiService falAiService;
+
+    /** Supabase Storage 파일 업로드 서비스 */
+    private final StorageService storageService;
+
+    /** 캐릭터 엔티티 생성·삭제 서비스 */
+    private final CharacterService characterService;
+
+    /** 배경 엔티티 생성·삭제 서비스 */
+    private final BackgroundService backgroundService;
 
     /**
      * FAL.ai로 이미지를 임시 생성한다 (DB 저장 없음)
@@ -115,6 +133,145 @@ public class AssetService {
     }
 
     // ─────────────────────────────────────────
+    // 신규 API: 통합 생성 / 개별 삭제
+    // ─────────────────────────────────────────
+
+    /**
+     * 자산 1단계 통합 생성 (Multipart)
+     *
+     * <p>처리 흐름:</p>
+     * <pre>
+     *   1. referenceImage → StorageService.uploadImage() → Supabase URL
+     *   2. name + style로 FAL.ai 프롬프트 자동 생성
+     *   3. FalAiService.generateImageSync(referenceImageUrl, prompt) → AI 이미지 URL
+     *   4. assetType 분기:
+     *      - "characters"  → CharacterService.createRaw() → CharacterEntity 저장
+     *      - "backgrounds" → BackgroundService.create()   → BackgroundEntity 저장
+     *   5. Asset 엔티티에도 AI 이미지 저장 (CHARACTER / BACKGROUND 타입)
+     *   6. AssetCreateResponse 반환
+     * </pre>
+     *
+     * @param projectId      소속 프로젝트 UUID (경로 변수)
+     * @param assetType      자산 종류 ("characters" 또는 "backgrounds")
+     * @param name           자산 이름 (필수)
+     * @param referenceImage 참조 이미지 파일 (Multipart, 필수)
+     * @param style          화풍 (예: REALISTIC, ANIME, 3D, PAINT, SKETCH, 필수)
+     * @param ratio          이미지 비율 (예: 16:9, 9:16, 1:1, 선택)
+     * @param quality        이미지 품질 (예: Standard, High, 선택)
+     * @return 생성된 자산 정보 (id, name, referenceImageUrl, imageUrl, status)
+     * @throws BusinessException 프로젝트 미존재(404), 잘못된 assetType(400), 생성 실패(502)
+     */
+    @Transactional
+    public AssetCreateResponse createAsset(String projectId, String assetType,
+                                           String name, MultipartFile referenceImage,
+                                           String style, String ratio, String quality) {
+        // 프로젝트 존재 여부 검증
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new BusinessException(
+                        "프로젝트를 찾을 수 없습니다. id=" + projectId, HttpStatus.NOT_FOUND));
+
+        // assetType 유효성 검증 (characters 또는 backgrounds만 허용)
+        if (!"characters".equals(assetType) && !"backgrounds".equals(assetType)) {
+            throw new BusinessException(
+                    "지원하지 않는 자산 유형입니다. assetType=" + assetType
+                    + " (허용값: characters, backgrounds)", HttpStatus.BAD_REQUEST);
+        }
+
+        // ── Step 1: 참조 이미지 → Supabase Storage 업로드 ──────────────────
+        log.info("참조 이미지 업로드 시작: projectId={}, assetType={}, name={}", projectId, assetType, name);
+        String referenceImageUrl = storageService.uploadImage(referenceImage);
+        log.info("참조 이미지 업로드 완료: referenceImageUrl={}", referenceImageUrl);
+
+        // ── Step 2: FAL.ai 프롬프트 생성 ────────────────────────────────────
+        String prompt = buildAssetPrompt(name, assetType, style, ratio, quality);
+
+        // ── Step 3: FAL.ai로 AI 이미지 생성 (동기) ──────────────────────────
+        log.info("AI 이미지 생성 시작: prompt={}", prompt);
+        String aiImageUrl;
+        try {
+            aiImageUrl = falAiService.generateImageSync(referenceImageUrl, prompt);
+        } catch (Exception e) {
+            log.error("AI 이미지 생성 실패: {}", e.getMessage());
+            throw new BusinessException("이미지 생성에 실패했습니다: " + e.getMessage(), HttpStatus.BAD_GATEWAY);
+        }
+        log.info("AI 이미지 생성 완료: imageUrl={}", aiImageUrl);
+
+        // ── Step 4: 자산 엔티티 저장 (Character / Background) ───────────────
+        String savedEntityId;
+        Asset.AssetType assetTypeEnum;
+
+        if ("characters".equals(assetType)) {
+            // 캐릭터 엔티티 생성 및 저장
+            Character character = characterService.createRaw(projectId, name, referenceImageUrl, style);
+            savedEntityId = character.getCharacterId();
+            assetTypeEnum = Asset.AssetType.CHARACTER;
+        } else {
+            // 배경 엔티티 생성 및 저장 (description은 null — 통합 생성에서는 별도 입력 없음)
+            BackgroundEntity background = backgroundService.create(
+                    projectId, name, null, referenceImageUrl, style);
+            savedEntityId = background.getBackgroundId();
+            assetTypeEnum = Asset.AssetType.BACKGROUND;
+        }
+
+        // ── Step 5: Asset 엔티티에 AI 이미지 저장 ───────────────────────────
+        Asset asset = Asset.builder()
+                .project(project)
+                .type(assetTypeEnum)
+                .imageUrl(aiImageUrl)
+                .prompt(prompt)
+                .style(style)
+                .build();
+        assetRepository.save(asset);
+        log.info("Asset 저장 완료: assetId={}, type={}, projectId={}",
+                asset.getAssetId(), assetTypeEnum, projectId);
+
+        // ── Step 6: 응답 반환 ────────────────────────────────────────────────
+        return AssetCreateResponse.builder()
+                .id(savedEntityId)
+                .name(name)
+                .referenceImageUrl(referenceImageUrl)
+                .imageUrl(aiImageUrl)
+                .status("COMPLETED")
+                .build();
+    }
+
+    /**
+     * 자산 개별 삭제
+     *
+     * <p>assetType에 따라 캐릭터 또는 배경 엔티티를 삭제한다.
+     * 연관 Asset 레코드는 별도로 정리하지 않으며, DB ON DELETE 정책에 따른다.</p>
+     *
+     * @param projectId 소속 프로젝트 UUID (경로 변수, 현재는 존재 확인용으로만 사용)
+     * @param assetType 자산 종류 ("characters" 또는 "backgrounds")
+     * @param assetId   삭제할 자산 UUID (characterId 또는 backgroundId)
+     * @throws BusinessException 프로젝트 미존재(404), 잘못된 assetType(400), 자산 미존재(404)
+     */
+    @Transactional
+    public void deleteAsset(String projectId, String assetType, String assetId) {
+        // 프로젝트 존재 여부 검증
+        if (!projectRepository.existsById(projectId)) {
+            throw new BusinessException(
+                    "프로젝트를 찾을 수 없습니다. id=" + projectId, HttpStatus.NOT_FOUND);
+        }
+
+        // assetType 유효성 검증
+        if (!"characters".equals(assetType) && !"backgrounds".equals(assetType)) {
+            throw new BusinessException(
+                    "지원하지 않는 자산 유형입니다. assetType=" + assetType
+                    + " (허용값: characters, backgrounds)", HttpStatus.BAD_REQUEST);
+        }
+
+        // 자산 유형별 삭제 처리
+        if ("characters".equals(assetType)) {
+            characterService.delete(assetId);
+            log.info("캐릭터 삭제 완료: projectId={}, characterId={}", projectId, assetId);
+        } else {
+            backgroundService.delete(assetId);
+            log.info("배경 삭제 완료: projectId={}, backgroundId={}", projectId, assetId);
+        }
+    }
+
+    // ─────────────────────────────────────────
     // private 헬퍼
     // ─────────────────────────────────────────
 
@@ -130,5 +287,53 @@ public class AssetService {
             return prompt + ", " + style + " style, high quality";
         }
         return prompt + ", high quality";
+    }
+
+    /**
+     * 통합 자산 생성용 FAL.ai 프롬프트를 구성한다.
+     *
+     * <p>자산 유형(characters / backgrounds)에 따라 프롬프트 패턴을 다르게 적용한다.
+     * ratio, quality 옵션이 있으면 프롬프트 끝에 추가한다.</p>
+     *
+     * @param name      자산 이름
+     * @param assetType 자산 유형 ("characters" 또는 "backgrounds")
+     * @param style     화풍 (예: REALISTIC, ANIME)
+     * @param ratio     이미지 비율 (null 허용, 예: 16:9)
+     * @param quality   이미지 품질 (null 허용, 예: Standard, High)
+     * @return 완성된 FAL.ai 이미지 생성 프롬프트
+     */
+    private String buildAssetPrompt(String name, String assetType,
+                                    String style, String ratio, String quality) {
+        StringBuilder sb = new StringBuilder();
+
+        if ("characters".equals(assetType)) {
+            // 캐릭터: 동일 외형·표정 유지를 위한 프롬프트 패턴
+            sb.append("character portrait of ").append(name)
+              .append(", full body, consistent appearance, ")
+              .append("keep the same character face and style as reference image");
+        } else {
+            // 배경: 배경 장면 생성 프롬프트 패턴
+            sb.append("background scene of ").append(name)
+              .append(", detailed environment, cinematic composition");
+        }
+
+        // 화풍 추가
+        if (style != null && !style.isBlank()) {
+            sb.append(", ").append(style.toLowerCase()).append(" style");
+        }
+
+        // 비율 추가
+        if (ratio != null && !ratio.isBlank()) {
+            sb.append(", aspect ratio ").append(ratio);
+        }
+
+        // 품질 추가
+        if ("High".equalsIgnoreCase(quality)) {
+            sb.append(", ultra high quality, 8k, highly detailed");
+        } else {
+            sb.append(", high quality");
+        }
+
+        return sb.toString();
     }
 }

--- a/src/main/java/com/estaid/asset/dto/AssetCreateResponse.java
+++ b/src/main/java/com/estaid/asset/dto/AssetCreateResponse.java
@@ -1,0 +1,52 @@
+package com.estaid.asset.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 자산 통합 생성 응답 DTO
+ *
+ * <p>캐릭터·배경 자산을 1단계로 통합 생성한 결과를 반환한다.
+ * 기존 2단계(generate → save) 방식과 달리,
+ * 이미지 업로드·AI 생성·엔티티 저장이 한 번에 처리된다.</p>
+ *
+ * <p>연관 엔드포인트:</p>
+ * <ul>
+ *   <li>POST /api/projects/{projectId}/characters  - 캐릭터 통합 생성</li>
+ *   <li>POST /api/projects/{projectId}/backgrounds - 배경 통합 생성</li>
+ * </ul>
+ */
+@Getter
+@Builder
+public class AssetCreateResponse {
+
+    /**
+     * 생성된 자산의 고유 식별자
+     * <ul>
+     *   <li>캐릭터: CharacterEntity.characterId</li>
+     *   <li>배경:    BackgroundEntity.backgroundId</li>
+     * </ul>
+     */
+    private String id;
+
+    /** 자산 이름 (사용자가 입력한 값) */
+    private String name;
+
+    /**
+     * 참조 이미지 URL (Supabase Storage에 업로드된 원본 이미지)
+     * FAL.ai FLUX Kontext 호출 시 image_url 파라미터로 전달된 값이다.
+     */
+    private String referenceImageUrl;
+
+    /**
+     * AI가 생성한 이미지 URL (FAL.ai FLUX Kontext 결과)
+     * 프론트엔드에서 생성된 자산 이미지를 표시할 때 사용한다.
+     */
+    private String imageUrl;
+
+    /**
+     * 생성 상태 — 현재는 항상 "COMPLETED"
+     * 동기 처리이므로 응답 시점에 이미 생성 완료 상태이다.
+     */
+    private String status;
+}

--- a/src/main/java/com/estaid/background/BackgroundService.java
+++ b/src/main/java/com/estaid/background/BackgroundService.java
@@ -1,0 +1,77 @@
+package com.estaid.background;
+
+import com.estaid.common.exception.BusinessException;
+import com.estaid.content.entity.BackgroundEntity;
+import com.estaid.content.repository.BackgroundRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 배경 자산 비즈니스 로직 서비스
+ *
+ * <p>배경 자산(BackgroundEntity) 생성·삭제를 담당한다.
+ * 캐릭터({@code CharacterService})와 동일한 패턴으로 구현된다.</p>
+ *
+ * <p>주요 기능:</p>
+ * <ul>
+ *   <li>{@link #create}  - 배경 엔티티 생성 및 저장</li>
+ *   <li>{@link #delete}  - 배경 엔티티 삭제</li>
+ * </ul>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BackgroundService {
+
+    /** 배경 엔티티 Repository */
+    private final BackgroundRepository backgroundRepository;
+
+    /**
+     * 배경 자산을 생성하고 DB에 저장한다.
+     *
+     * @param projectId         소속 프로젝트 UUID
+     * @param name              배경 이름
+     * @param description       배경 설명
+     * @param referenceImageUrl Supabase Storage에 업로드된 참조 이미지 URL
+     * @param artStyle          화풍 (예: REALISTIC, ANIME)
+     * @return 저장된 배경 엔티티
+     */
+    @Transactional
+    public BackgroundEntity create(String projectId, String name, String description,
+                                   String referenceImageUrl, String artStyle) {
+        // 배경 엔티티 생성 및 저장
+        BackgroundEntity background = BackgroundEntity.builder()
+                .projectId(projectId)
+                .name(name)
+                .description(description)
+                .referenceImageUrl(referenceImageUrl)
+                .artStyle(artStyle)
+                .build();
+
+        BackgroundEntity saved = backgroundRepository.save(background);
+        log.info("배경 생성 완료: backgroundId={}, name={}, projectId={}",
+                saved.getBackgroundId(), saved.getName(), projectId);
+        return saved;
+    }
+
+    /**
+     * 배경 자산을 삭제한다.
+     *
+     * <p>DB의 plots.background_id는 FK이므로, 해당 배경을 참조하는 플롯이 있다면
+     * DB 제약에 따라 처리된다. (schema.sql의 ON DELETE 정책 확인 필요)</p>
+     *
+     * @param backgroundId 삭제할 배경 UUID
+     * @throws BusinessException 배경이 존재하지 않을 때 (404)
+     */
+    @Transactional
+    public void delete(String backgroundId) {
+        BackgroundEntity background = backgroundRepository.findById(backgroundId)
+                .orElseThrow(() -> new BusinessException(
+                        "배경을 찾을 수 없습니다. id=" + backgroundId, HttpStatus.NOT_FOUND));
+        backgroundRepository.delete(background);
+        log.info("배경 삭제 완료: backgroundId={}", backgroundId);
+    }
+}

--- a/src/main/java/com/estaid/character/CharacterService.java
+++ b/src/main/java/com/estaid/character/CharacterService.java
@@ -85,6 +85,39 @@ public class CharacterService {
     }
 
     /**
+     * 캐릭터 생성 (통합 자산 생성 API용 — 파라미터 직접 전달 방식)
+     *
+     * <p>{@link #create(CharacterRequest)}와 동일한 로직이지만,
+     * Multipart 요청에서 이미 파싱된 개별 값을 직접 받아 처리한다.
+     * AssetService 통합 생성 흐름에서 호출된다.</p>
+     *
+     * @param projectId         소속 프로젝트 UUID
+     * @param name              캐릭터 이름
+     * @param referenceImageUrl Supabase Storage에 업로드된 참조 이미지 URL
+     * @param artStyle          화풍 (예: REALISTIC, ANIME)
+     * @return 저장된 캐릭터 엔티티
+     * @throws BusinessException 프로젝트가 존재하지 않을 때 (404)
+     */
+    @Transactional
+    public Character createRaw(String projectId, String name,
+                               String referenceImageUrl, String artStyle) {
+        Project project = getProjectOrThrow(projectId);
+
+        // 캐릭터 엔티티 생성 및 저장
+        Character character = Character.builder()
+                .project(project)
+                .name(name)
+                .referenceImageUrl(referenceImageUrl)
+                .artStyle(artStyle)
+                .build();
+
+        Character saved = characterRepository.save(character);
+        log.info("캐릭터 생성 완료 (통합 API): characterId={}, name={}, projectId={}",
+                saved.getCharacterId(), name, projectId);
+        return saved;
+    }
+
+    /**
      * 캐릭터 수정
      *
      * <p>전달된 필드로 기존 값을 덮어쓴다.

--- a/src/main/java/com/estaid/common/service/ClaudeService.java
+++ b/src/main/java/com/estaid/common/service/ClaudeService.java
@@ -61,30 +61,27 @@ public class ClaudeService {
     }
 
     /**
-     * 플롯 아이디어를 기반으로 Claude API를 호출하여 씬 목록을 생성한다.
+     * 스토리 설명을 기반으로 Claude API를 호출하여 씬 목록을 생성한다.
      *
      * <p>호출 흐름:</p>
      * <pre>
-     *   1. 씬 생성 프롬프트 구성 (제목, 아이디어, 씬 수, 아트스타일, 캐릭터 정보)
+     *   1. 씬 생성 프롬프트 구성 (스토리 설명, 씬 수, 비율)
      *   2. Claude API POST /v1/messages 동기 호출
      *   3. 응답 텍스트에서 JSON 배열 추출
      *   4. List&lt;SceneDto&gt;로 역직렬화하여 반환
      * </pre>
      *
-     * @param title      플롯 제목
-     * @param idea       사용자가 입력한 스토리 아이디어
-     * @param sceneCount 생성할 씬 수 (1~10)
-     * @param artStyle   화풍 설정 (예: anime, realistic)
-     * @param character  참조 캐릭터 (null 허용 — 없으면 캐릭터 정보 제외)
+     * @param storyDescription 사용자가 입력한 전체 줄거리 텍스트
+     * @param sceneCount       생성할 씬 수 (1~10)
+     * @param ratio            영상 비율 (예: "16:9", null 허용)
      * @return Claude가 생성한 씬 목록
      * @throws BusinessException Claude API 호출 실패 또는 응답 파싱 실패 시
      */
-    public List<SceneDto> generateScenes(String title, String idea, int sceneCount,
-                                         String artStyle, Character character) {
-        log.info("Claude 씬 생성 요청: title={}, sceneCount={}, artStyle={}", title, sceneCount, artStyle);
+    public List<SceneDto> generateScenes(String storyDescription, int sceneCount, String ratio) {
+        log.info("Claude 씬 생성 요청: sceneCount={}, ratio={}", sceneCount, ratio);
 
         // 1. 프롬프트 구성
-        String userPrompt = buildScenePrompt(title, idea, sceneCount, artStyle, character);
+        String userPrompt = buildScenePrompt(storyDescription, sceneCount, ratio);
 
         // 2. Claude API 요청 바디 구성
         Map<String, Object> requestBody = Map.of(
@@ -191,24 +188,19 @@ public class ClaudeService {
 
     /**
      * 씬 생성용 사용자 프롬프트를 구성한다.
-     * 캐릭터가 있으면 이름·설명을 포함하여 씬 내 캐릭터 묘사 일관성을 높인다.
+     * storyDescription과 씬 수, 비율을 기반으로 Claude에게 전달할 프롬프트를 만든다.
+     *
+     * @param storyDescription 전체 줄거리 텍스트
+     * @param sceneCount       생성할 씬 수
+     * @param ratio            영상 비율 (null 허용)
      */
-    private String buildScenePrompt(String title, String idea, int sceneCount,
-                                    String artStyle, Character character) {
+    private String buildScenePrompt(String storyDescription, int sceneCount, String ratio) {
         StringBuilder sb = new StringBuilder();
-        sb.append("제목: ").append(title).append("\n");
-        sb.append("아이디어: ").append(idea).append("\n");
+        sb.append("줄거리: ").append(storyDescription).append("\n");
         sb.append("씬 수: ").append(sceneCount).append("개\n");
 
-        if (artStyle != null && !artStyle.isBlank()) {
-            sb.append("아트 스타일: ").append(artStyle).append("\n");
-        }
-        if (character != null) {
-            sb.append("캐릭터: ").append(character.getName());
-            if (character.getDescription() != null && !character.getDescription().isBlank()) {
-                sb.append(" - ").append(character.getDescription());
-            }
-            sb.append("\n");
+        if (ratio != null && !ratio.isBlank()) {
+            sb.append("영상 비율: ").append(ratio).append("\n");
         }
 
         sb.append("\n다음 JSON 형식으로 정확히 ").append(sceneCount).append("개의 씬을 생성해주세요.\n");
@@ -265,13 +257,19 @@ public class ClaudeService {
     /** 씬 생성 시스템 프롬프트 */
     private static final String SCENE_SYSTEM_PROMPT =
             "당신은 2차 창작 만화/영상의 스토리보드 작가입니다.\n" +
-            "사용자의 아이디어를 받아 지정된 수의 씬으로 구성된 플롯을 JSON 형식으로 생성하세요.\n" +
+            "사용자의 줄거리를 받아 지정된 수의 씬으로 구성된 스토리보드를 JSON 형식으로 생성하세요.\n" +
             "각 씬은 영상 제작에 필요한 구체적인 정보를 포함해야 합니다.\n" +
+            "composition 필드는 반드시 아래 10가지 값 중 하나만 사용하세요:\n" +
+            "EXTREME_CLOSEUP, HIGH_ANGLE, LOW_ANGLE, MEDIUM_SHOT, OVER_THE_SHOULDER, " +
+            "TWO_SHOT, WIDE_SHOT, BIRD_EYE_VIEW, CLOSEUP, DUTCH_ANGLE\n" +
             "반드시 JSON 배열만 반환하고, 다른 텍스트나 설명은 절대 포함하지 마세요.";
 
     /**
      * 영상 프롬프트 생성용 사용자 프롬프트를 구성한다.
      * 씬의 모든 시각적 정보를 포함하여 일관된 영상 프롬프트를 생성한다.
+     *
+     * @param scene    씬 정보 DTO
+     * @param artStyle 화풍 설정 (null 허용)
      */
     private String buildVideoPromptRequest(SceneDto scene, String artStyle) {
         StringBuilder sb = new StringBuilder();
@@ -282,8 +280,14 @@ public class ClaudeService {
         sb.append("등장인물: ").append(scene.getCharacters()).append("\n");
         sb.append("카메라 구도: ").append(scene.getComposition()).append("\n");
         sb.append("배경: ").append(scene.getBackground()).append("\n");
+        // backgroundDetail이 있으면 배경 상세 묘사를 추가로 전달한다
+        if (scene.getBackgroundDetail() != null && !scene.getBackgroundDetail().isBlank()) {
+            sb.append("배경 상세: ").append(scene.getBackgroundDetail()).append("\n");
+        }
         sb.append("조명/분위기: ").append(scene.getLighting()).append("\n");
-        sb.append("주요 스토리: ").append(scene.getMainStory()).append("\n");
+        // majorStory가 있으면 우선 사용, 없으면 빈 값
+        String story = scene.getMajorStory();
+        sb.append("주요 스토리: ").append(story != null ? story : "").append("\n");
         sb.append("첫 프레임 묘사: ").append(scene.getFirstFramePrompt()).append("\n");
         sb.append("마지막 프레임 묘사: ").append(scene.getLastFramePrompt()).append("\n");
         if (artStyle != null && !artStyle.isBlank()) {
@@ -300,17 +304,28 @@ public class ClaudeService {
             "반드시 영어로만 작성하고, 설명이나 부연 없이 프롬프트 텍스트만 반환하세요.\n" +
             "길이는 2~3문장으로 작성하세요.";
 
-    /** 씬 JSON 형식 예시 (Claude에게 출력 포맷 안내) */
+    /**
+     * 씬 JSON 형식 예시 (Claude에게 출력 포맷 안내)
+     *
+     * <p>주요 필드 변경 사항:</p>
+     * <ul>
+     *   <li>composition: 반드시 Enum 10가지 중 하나 (EXTREME_CLOSEUP 등)</li>
+     *   <li>background: 배경 장소 이름 (1~3단어)</li>
+     *   <li>backgroundDetail: 배경 상세 묘사 (영어, 이미지 생성용)</li>
+     *   <li>majorStory: 씬 구체적 설명 (기존 mainStory 대체)</li>
+     * </ul>
+     */
     private static final String SCENE_JSON_FORMAT =
             "[\n" +
             "  {\n" +
             "    \"sceneNumber\": 1,\n" +
             "    \"title\": \"씬 제목\",\n" +
             "    \"characters\": \"등장인물\",\n" +
-            "    \"composition\": \"카메라 구도 (예: wide shot, close-up, low angle)\",\n" +
-            "    \"background\": \"배경 묘사\",\n" +
-            "    \"lighting\": \"조명/분위기\",\n" +
-            "    \"mainStory\": \"주요 스토리 (2~3문장)\",\n" +
+            "    \"composition\": \"반드시 다음 중 하나: EXTREME_CLOSEUP, HIGH_ANGLE, LOW_ANGLE, MEDIUM_SHOT, OVER_THE_SHOULDER, TWO_SHOT, WIDE_SHOT, BIRD_EYE_VIEW, CLOSEUP, DUTCH_ANGLE\",\n" +
+            "    \"background\": \"배경 장소 이름 (1~3단어, 예: 어두운 숲)\",\n" +
+            "    \"backgroundDetail\": \"배경 상세 묘사 (영어, 이미지 생성 프롬프트용, 예: Dense pine forest with moonlight)\",\n" +
+            "    \"lighting\": \"조명/분위기 (영어 권장)\",\n" +
+            "    \"majorStory\": \"씬에 대한 구체적 설명/사건 (2~3문장)\",\n" +
             "    \"firstFramePrompt\": \"영어 이미지 생성 프롬프트 (첫 프레임)\",\n" +
             "    \"lastFramePrompt\": \"영어 이미지 생성 프롬프트 (마지막 프레임)\"\n" +
             "  }\n" +

--- a/src/main/java/com/estaid/content/controller/ProjectQueryController.java
+++ b/src/main/java/com/estaid/content/controller/ProjectQueryController.java
@@ -5,6 +5,7 @@ import com.estaid.common.response.ApiResponse;
 import com.estaid.content.dto.ProjectDetailResponse;
 import com.estaid.content.dto.ProjectRankingResponse;
 import com.estaid.content.dto.ProjectScenesResponse;
+import com.estaid.content.dto.VideoPageInitResponse;
 import com.estaid.content.service.ContentQueryService;
 import com.estaid.project.ProjectService;
 import com.estaid.project.dto.ProjectResponse;
@@ -51,5 +52,23 @@ public class ProjectQueryController {
             HttpServletRequest request) {
         String userId = authenticatedUserService.requireCurrentUserId(request);
         return ApiResponse.ok(contentQueryService.getProjectScenes(projectId, userId));
+    }
+
+    /**
+     * 영상 페이지 초기 정보 조회
+     *
+     * <p>영상 생성 페이지 진입 시 씬별 프레임 이미지 URL과 통합 프롬프트를 반환한다.
+     * 프론트엔드는 이 정보를 사용해 영상 생성 요청({@code POST /api/videos/generate})을 구성한다.</p>
+     *
+     * @param projectId 프로젝트 UUID (경로 변수)
+     * @param request   HTTP 요청 (JWT 사용자 인증용)
+     * @return 영상 페이지 초기 정보 (씬 번호 오름차순)
+     */
+    @GetMapping("/{id}/video-info")
+    public ApiResponse<VideoPageInitResponse> getVideoPageInfo(
+            @PathVariable("id") String projectId,
+            HttpServletRequest request) {
+        String userId = authenticatedUserService.requireCurrentUserId(request);
+        return ApiResponse.ok(contentQueryService.getVideoPageInfo(projectId, userId));
     }
 }

--- a/src/main/java/com/estaid/content/dto/AssetItemResponse.java
+++ b/src/main/java/com/estaid/content/dto/AssetItemResponse.java
@@ -1,0 +1,22 @@
+package com.estaid.content.dto;
+
+/**
+ * 프로젝트 자산(Asset) 요약 응답 DTO
+ *
+ * <p>프로젝트 상세 조회 시 에셋 목록을 반환할 때 사용한다.
+ * 에셋의 이미지 URL과 생성 프롬프트만 포함한다.</p>
+ *
+ * <p>연관 응답: {@link ProjectDetailResponse#assets()}</p>
+ *
+ * @param assetId  에셋 고유 식별자 (UUID)
+ * @param type     에셋 종류 ("CHARACTER" 또는 "BACKGROUND")
+ * @param imageUrl AI가 생성한 에셋 이미지 URL (FAL.ai 결과)
+ * @param prompt   이미지 생성에 사용한 프롬프트 (null 가능)
+ */
+public record AssetItemResponse(
+        String assetId,
+        String type,
+        String imageUrl,
+        String prompt
+) {
+}

--- a/src/main/java/com/estaid/content/dto/ProjectDetailResponse.java
+++ b/src/main/java/com/estaid/content/dto/ProjectDetailResponse.java
@@ -3,12 +3,26 @@ package com.estaid.content.dto;
 import java.time.OffsetDateTime;
 import java.util.List;
 
+/**
+ * 프로젝트 상세 조회 응답 DTO
+ *
+ * <p>프로젝트 상세 페이지에서 씬 목록, 에셋 목록, 프로젝트 기본 정보를 반환한다.</p>
+ *
+ * @param projectId          프로젝트 UUID
+ * @param title              프로젝트 제목
+ * @param backgroundImageUrl 프로젝트 대표 배경 이미지 URL (null 가능)
+ * @param createdAt          프로젝트 생성 시각
+ * @param updatedAt          프로젝트 최종 수정 시각
+ * @param scenes             씬 목록 (씬 번호 오름차순)
+ * @param assets             에셋 목록 — 캐릭터·배경 이미지 (생성 시각 오름차순)
+ */
 public record ProjectDetailResponse(
         String projectId,
         String title,
         String backgroundImageUrl,
         OffsetDateTime createdAt,
         OffsetDateTime updatedAt,
-        List<ProjectSceneDetailResponse> scenes
+        List<ProjectSceneDetailResponse> scenes,
+        List<AssetItemResponse> assets
 ) {
 }

--- a/src/main/java/com/estaid/content/dto/ProjectSceneDetailResponse.java
+++ b/src/main/java/com/estaid/content/dto/ProjectSceneDetailResponse.java
@@ -2,10 +2,26 @@ package com.estaid.content.dto;
 
 import java.util.List;
 
+/**
+ * 프로젝트 상세 조회 — 씬 단위 응답 DTO
+ *
+ * <p>프로젝트 상세 페이지에서 각 씬의 정보(이미지·영상·제목·썸네일)를 반환한다.</p>
+ *
+ * @param plotId      씬이 속한 플롯 UUID
+ * @param plotTitle   플롯 제목
+ * @param sceneNumber 씬 순서 번호 (1부터 시작)
+ * @param sceneTitle  씬 제목 (PlotEntity.scenesJson에서 파싱, 없으면 null)
+ * @param thumbnail   썸네일 이미지 URL
+ *                    (SceneDto.firstFrameImageUrl → 없으면 Image 테이블 FIRST 프레임 URL → 없으면 null)
+ * @param images      씬의 이미지 목록 (프레임 타입 순)
+ * @param video       씬의 영상 정보 (없으면 null)
+ */
 public record ProjectSceneDetailResponse(
         String plotId,
         String plotTitle,
         Integer sceneNumber,
+        String sceneTitle,
+        String thumbnail,
         List<SceneImageItemResponse> images,
         SceneVideoResponse video
 ) {

--- a/src/main/java/com/estaid/content/dto/VideoPageInitResponse.java
+++ b/src/main/java/com/estaid/content/dto/VideoPageInitResponse.java
@@ -1,0 +1,20 @@
+package com.estaid.content.dto;
+
+import java.util.List;
+
+/**
+ * 영상 페이지 초기 정보 응답 DTO
+ *
+ * <p>영상 생성 페이지 진입 시 해당 프로젝트의 모든 씬에 대한
+ * 프레임 이미지 URL과 통합 영상 프롬프트를 한 번에 반환한다.</p>
+ *
+ * <p>연관 엔드포인트: {@code GET /projects/{id}/video-info}</p>
+ *
+ * @param projectId 프로젝트 UUID
+ * @param scenes    씬별 영상 초기 정보 목록 (씬 번호 오름차순)
+ */
+public record VideoPageInitResponse(
+        String projectId,
+        List<VideoSceneInfoResponse> scenes
+) {
+}

--- a/src/main/java/com/estaid/content/dto/VideoSceneInfoResponse.java
+++ b/src/main/java/com/estaid/content/dto/VideoSceneInfoResponse.java
@@ -1,0 +1,27 @@
+package com.estaid.content.dto;
+
+/**
+ * 영상 페이지 초기 정보 — 씬 단위 응답 DTO
+ *
+ * <p>영상 생성 페이지에서 각 씬의 프레임 이미지 URL과 통합 프롬프트를 제공한다.
+ * 이 정보를 바탕으로 프론트엔드는 씬별 영상 생성 요청을 구성한다.</p>
+ *
+ * <p>연관 응답: {@link VideoPageInitResponse#scenes()}</p>
+ *
+ * @param sceneNumber    씬 순서 번호 (1부터 시작)
+ * @param title          씬 제목 (PlotEntity.scenesJson에서 파싱, 없으면 null)
+ * @param firstFrameUrl  첫 프레임 이미지 URL
+ *                       (SceneDto.firstFrameImageUrl → 없으면 Image 테이블 FIRST 프레임 URL)
+ * @param lastFrameUrl   마지막 프레임 이미지 URL
+ *                       (SceneDto.lastFrameImageUrl  → 없으면 Image 테이블 LAST  프레임 URL)
+ * @param combinedPrompt 영상 생성에 사용할 통합 프롬프트
+ *                       (기존 Video.videoPrompt 우선 → 없으면 firstFramePrompt + lastFramePrompt)
+ */
+public record VideoSceneInfoResponse(
+        Integer sceneNumber,
+        String title,
+        String firstFrameUrl,
+        String lastFrameUrl,
+        String combinedPrompt
+) {
+}

--- a/src/main/java/com/estaid/content/entity/BackgroundEntity.java
+++ b/src/main/java/com/estaid/content/entity/BackgroundEntity.java
@@ -1,42 +1,81 @@
 package com.estaid.content.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import java.time.OffsetDateTime;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
-/** backgrounds 테이블 매핑 엔티티. */
+/**
+ * backgrounds 테이블 매핑 엔티티
+ *
+ * <p>배경 자산 정보를 저장한다. 캐릭터(characters 테이블)와 동일한 구조를 가지며,
+ * 프로젝트({@code project_id})에 속한다.</p>
+ *
+ * <p>DB 테이블: {@code backgrounds}</p>
+ *
+ * <p>주요 필드:</p>
+ * <ul>
+ *   <li>backgroundId      - UUID (자동 생성)</li>
+ *   <li>projectId         - 소속 프로젝트 UUID</li>
+ *   <li>name              - 배경 이름</li>
+ *   <li>description       - 배경 설명</li>
+ *   <li>referenceImageUrl - 참조 이미지 URL (Supabase Storage)</li>
+ *   <li>artStyle          - 화풍</li>
+ * </ul>
+ */
 @Getter
+@Setter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 @Entity
 @Table(name = "backgrounds")
 public class BackgroundEntity {
 
+    /** 배경 고유 식별자 (UUID, 자동 생성) */
     @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "background_id", nullable = false, length = 36)
     private String backgroundId;
 
+    /** 소속 프로젝트 UUID */
     @Column(name = "project_id", length = 36)
     private String projectId;
 
+    /** 배경 이름 (예: "어두운 숲", "도심 옥상") */
     @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(name = "description")
+    /** 배경 설명 (사용자 입력 또는 AI 생성 상세 묘사) */
+    @Column(name = "description", columnDefinition = "TEXT")
     private String description;
 
+    /** 참조 이미지 URL (Supabase Storage에 업로드된 원본 이미지) */
     @Column(name = "reference_image_url")
     private String referenceImageUrl;
 
+    /** 화풍 (예: REALISTIC, ANIME, 3D, PAINT, SKETCH) */
     @Column(name = "art_style")
     private String artStyle;
 
-    @Column(name = "created_at", nullable = false)
+    /** 생성 시각 (자동 설정, 수정 불가) */
+    @Column(name = "created_at", nullable = false, updatable = false)
     private OffsetDateTime createdAt;
 
+    /** 수정 시각 */
     @Column(name = "updated_at", nullable = false)
     private OffsetDateTime updatedAt;
+
+    /** 엔티티 저장 전 생성/수정 시각을 자동으로 설정한다. */
+    @PrePersist
+    private void prePersist() {
+        OffsetDateTime now = OffsetDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    /** 엔티티 수정 전 수정 시각을 자동으로 갱신한다. */
+    @PreUpdate
+    private void preUpdate() {
+        this.updatedAt = OffsetDateTime.now();
+    }
 }

--- a/src/main/java/com/estaid/content/repository/BackgroundRepository.java
+++ b/src/main/java/com/estaid/content/repository/BackgroundRepository.java
@@ -3,6 +3,21 @@ package com.estaid.content.repository;
 import com.estaid.content.entity.BackgroundEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-/** 배경 엔티티 저장소. */
+import java.util.List;
+
+/**
+ * 배경(BackgroundEntity) Repository
+ *
+ * <p>Spring Data JPA가 런타임에 구현체를 자동 생성한다.
+ * 기본 CRUD는 {@link JpaRepository}에서 상속한다.</p>
+ */
 public interface BackgroundRepository extends JpaRepository<BackgroundEntity, String> {
+
+    /**
+     * 특정 프로젝트에 속한 배경 목록을 조회한다.
+     *
+     * @param projectId 프로젝트 UUID
+     * @return 해당 프로젝트의 배경 목록
+     */
+    List<BackgroundEntity> findByProjectId(String projectId);
 }

--- a/src/main/java/com/estaid/content/service/ContentQueryService.java
+++ b/src/main/java/com/estaid/content/service/ContentQueryService.java
@@ -1,6 +1,9 @@
 package com.estaid.content.service;
 
+import com.estaid.asset.Asset;
+import com.estaid.asset.AssetRepository;
 import com.estaid.common.exception.BusinessException;
+import com.estaid.content.dto.AssetItemResponse;
 import com.estaid.content.dto.GalleryItemResponse;
 import com.estaid.content.dto.ImagePromptResponse;
 import com.estaid.content.dto.PlotBackgroundResponse;
@@ -14,7 +17,9 @@ import com.estaid.content.dto.ProjectScenesResponse;
 import com.estaid.content.dto.SceneImageItemResponse;
 import com.estaid.content.dto.SceneImagesResponse;
 import com.estaid.content.dto.SceneVideoResponse;
+import com.estaid.content.dto.VideoPageInitResponse;
 import com.estaid.content.dto.VideoPromptResponse;
+import com.estaid.content.dto.VideoSceneInfoResponse;
 import com.estaid.content.dto.VideoUrlResponse;
 import com.estaid.content.entity.BackgroundEntity;
 import com.estaid.content.entity.CharacterEntity;
@@ -24,11 +29,14 @@ import com.estaid.content.entity.ProjectEntity;
 import com.estaid.content.entity.VideoEntity;
 import com.estaid.content.repository.BackgroundRepository;
 import com.estaid.content.repository.CharacterRepository;
-import com.estaid.content.repository.ImageRepository;   
+import com.estaid.content.repository.ImageRepository;
 import com.estaid.content.repository.PlotRepository;
 import com.estaid.content.repository.ProjectRepository;
 import com.estaid.content.repository.VideoRepository;
+import com.estaid.plot.dto.SceneDto;
 import com.estaid.user.UserRepository;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -36,15 +44,32 @@ import java.util.List;
 import java.util.Optional;
 import java.util.TreeSet;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * 콘텐츠 조회 서비스
+ *
+ * <p>프로젝트·씬·이미지·영상·갤러리 등 조회 전용 로직을 담당한다.
+ * 모든 메서드는 읽기 전용 트랜잭션({@code @Transactional(readOnly = true)})으로 실행된다.</p>
+ *
+ * <p>주요 기능:</p>
+ * <ul>
+ *   <li>{@link #getProjectDetail}   - 프로젝트 상세 (씬 목록 + 에셋 목록)</li>
+ *   <li>{@link #getVideoPageInfo}   - 영상 페이지 초기 정보 (씬별 프레임 URL + 통합 프롬프트)</li>
+ *   <li>{@link #getGallery}         - 공개 갤러리 조회</li>
+ *   <li>{@link #getProjectRanking}  - 프로젝트 랭킹</li>
+ * </ul>
+ */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ContentQueryService {
 
+    /** 씬 단위 영상 타입 문자열 (videos.video_type 컬럼 값) */
     private static final String VIDEO_TYPE_SCENE = "SCENE";
 
     private final ProjectRepository projectRepository;
@@ -54,6 +79,12 @@ public class ContentQueryService {
     private final CharacterRepository characterRepository;
     private final BackgroundRepository backgroundRepository;
     private final UserRepository userRepository;
+
+    /** 에셋 Repository (캐릭터·배경 이미지 조회용) */
+    private final AssetRepository assetRepository;
+
+    /** JSON 역직렬화 (scenesJson → List&lt;SceneDto&gt;) */
+    private final ObjectMapper objectMapper;
 
     public List<GalleryItemResponse> getGallery(String currentUserId) {
         List<ProjectEntity> projects = projectRepository.findByUserIdNotOrderByCreatedAtDesc(currentUserId);
@@ -123,16 +154,60 @@ public class ContentQueryService {
         return rankings;
     }
 
+    /**
+     * 프로젝트 상세 조회
+     *
+     * <p>프로젝트에 속한 플롯의 씬 목록과 에셋 목록을 포함하여 반환한다.</p>
+     *
+     * <p>씬 정보 보강:</p>
+     * <ul>
+     *   <li>sceneTitle  — scenesJson에서 파싱하여 추가</li>
+     *   <li>thumbnail   — SceneDto.firstFrameImageUrl → Image 테이블 FIRST 프레임 순으로 탐색</li>
+     * </ul>
+     *
+     * @param projectId 프로젝트 UUID
+     * @param userId    요청자 사용자 UUID (소유권 검증)
+     * @return 프로젝트 상세 응답 (씬 목록 + 에셋 목록)
+     * @throws BusinessException 프로젝트 미존재(404) 또는 소유권 불일치(404) 시
+     */
     public ProjectDetailResponse getProjectDetail(String projectId, String userId) {
         ProjectEntity project = findOwnedProjectOrThrow(projectId, userId);
         List<ProjectSceneDetailResponse> scenes = new ArrayList<>();
 
         for (PlotEntity plot : plotRepository.findByProjectIdOrderByCreatedAtAsc(projectId)) {
+            // scenesJson 파싱 → sceneNumber별 title/firstFrameImageUrl 추출용 맵
+            List<SceneDto> sceneDtos = parseScenes(plot.getScenesJson());
+
             for (Integer sceneNumber : sceneNumbersForPlot(plot.getPlotId())) {
+                // SceneDto에서 해당 씬의 title과 thumbnail 탐색
+                SceneDto matchedDto = sceneDtos.stream()
+                        .filter(dto -> dto.getSceneNumber() == sceneNumber)
+                        .findFirst()
+                        .orElse(null);
+
+                // sceneTitle: SceneDto.title 사용 (없으면 null)
+                String sceneTitle = matchedDto != null ? matchedDto.getTitle() : null;
+
+                // thumbnail: SceneDto.firstFrameImageUrl → Image 테이블 FIRST 프레임
+                String thumbnail = matchedDto != null ? matchedDto.getFirstFrameImageUrl() : null;
+                if (thumbnail == null) {
+                    // SceneDto에 없으면 Image 테이블에서 FIRST 프레임 탐색
+                    thumbnail = imageRepository.findByPlotIdAndSceneNumberOrderByFrameTypeAsc(
+                                    plot.getPlotId(), sceneNumber)
+                            .stream()
+                            .filter(img -> "FIRST".equals(img.getFrameType()))
+                            .map(ImageEntity::getImageUrl)
+                            .filter(url -> url != null && !url.isBlank())
+                            .findFirst()
+                            .orElse(null);
+                }
+
                 scenes.add(new ProjectSceneDetailResponse(
                         plot.getPlotId(),
                         plot.getTitle(),
                         sceneNumber,
+                        sceneTitle,
+                        thumbnail,
                         toSceneImageItems(plot.getPlotId(), sceneNumber),
                         findSceneVideo(plot.getPlotId(), sceneNumber)
                                 .map(this::toSceneVideoResponse)
@@ -140,13 +215,135 @@ public class ContentQueryService {
             }
         }
 
+        // 에셋 목록 조회 (캐릭터·배경 이미지, 생성 시각 오름차순)
+        List<AssetItemResponse> assets = assetRepository
+                .findByProject_ProjectIdOrderByCreatedAtAsc(projectId)
+                .stream()
+                .map(asset -> new AssetItemResponse(
+                        asset.getAssetId(),
+                        asset.getType() != null ? asset.getType().name() : null,
+                        asset.getImageUrl(),
+                        asset.getPrompt()))
+                .toList();
+
         return new ProjectDetailResponse(
                 project.getProjectId(),
                 project.getTitle(),
                 project.getBackgroundImageUrl(),
                 project.getCreatedAt(),
                 project.getUpdatedAt(),
-                scenes);
+                scenes,
+                assets);
+    }
+
+    /**
+     * 영상 페이지 초기 정보 조회
+     *
+     * <p>영상 생성 페이지 진입 시 해당 프로젝트의 씬별 프레임 이미지 URL과
+     * 통합 영상 프롬프트를 반환한다.</p>
+     *
+     * <p>정보 탐색 우선순위:</p>
+     * <ul>
+     *   <li>firstFrameUrl  — SceneDto.firstFrameImageUrl → Image 테이블 FIRST 프레임</li>
+     *   <li>lastFrameUrl   — SceneDto.lastFrameImageUrl  → Image 테이블 LAST  프레임</li>
+     *   <li>combinedPrompt — Video.videoPrompt (기존 영상이 있으면) → firstFramePrompt + lastFramePrompt</li>
+     * </ul>
+     *
+     * @param projectId 프로젝트 UUID
+     * @param userId    요청자 사용자 UUID (소유권 검증)
+     * @return 영상 페이지 초기 정보 (씬 번호 오름차순)
+     * @throws BusinessException 프로젝트 미존재(404) 또는 소유권 불일치(404) 시
+     */
+    public VideoPageInitResponse getVideoPageInfo(String projectId, String userId) {
+        findOwnedProjectOrThrow(projectId, userId);
+
+        List<VideoSceneInfoResponse> sceneInfos = new ArrayList<>();
+
+        for (PlotEntity plot : plotRepository.findByProjectIdOrderByCreatedAtAsc(projectId)) {
+            List<SceneDto> sceneDtos = parseScenes(plot.getScenesJson());
+
+            // scenesJson에 씬이 있으면 SceneDto 기반으로 구성
+            if (!sceneDtos.isEmpty()) {
+                for (SceneDto dto : sceneDtos) {
+                    // ── firstFrameUrl ────────────────────────────────
+                    String firstFrameUrl = dto.getFirstFrameImageUrl();
+                    if (firstFrameUrl == null) {
+                        // Image 테이블 FIRST 프레임으로 폴백
+                        firstFrameUrl = imageRepository
+                                .findByPlotIdAndSceneNumberOrderByFrameTypeAsc(
+                                        plot.getPlotId(), dto.getSceneNumber())
+                                .stream()
+                                .filter(img -> "FIRST".equals(img.getFrameType()))
+                                .map(ImageEntity::getImageUrl)
+                                .filter(url -> url != null && !url.isBlank())
+                                .findFirst()
+                                .orElse(null);
+                    }
+
+                    // ── lastFrameUrl ─────────────────────────────────
+                    String lastFrameUrl = dto.getLastFrameImageUrl();
+                    if (lastFrameUrl == null) {
+                        // Image 테이블 LAST 프레임으로 폴백
+                        lastFrameUrl = imageRepository
+                                .findByPlotIdAndSceneNumberOrderByFrameTypeAsc(
+                                        plot.getPlotId(), dto.getSceneNumber())
+                                .stream()
+                                .filter(img -> "LAST".equals(img.getFrameType()))
+                                .map(ImageEntity::getImageUrl)
+                                .filter(url -> url != null && !url.isBlank())
+                                .findFirst()
+                                .orElse(null);
+                    }
+
+                    // ── combinedPrompt ────────────────────────────────
+                    // 기존 Video.videoPrompt가 있으면 우선 사용, 없으면 프레임 프롬프트 합산
+                    String combinedPrompt = findSceneVideo(plot.getPlotId(), dto.getSceneNumber())
+                            .map(VideoEntity::getVideoPrompt)
+                            .filter(p -> p != null && !p.isBlank())
+                            .orElseGet(() -> buildCombinedPrompt(
+                                    dto.getFirstFramePrompt(), dto.getLastFramePrompt()));
+
+                    sceneInfos.add(new VideoSceneInfoResponse(
+                            dto.getSceneNumber(),
+                            dto.getTitle(),
+                            firstFrameUrl,
+                            lastFrameUrl,
+                            combinedPrompt));
+                }
+            } else {
+                // scenesJson이 없으면 Image 테이블 기반으로 구성 (하위 호환)
+                for (Integer sceneNumber : sceneNumbersForPlot(plot.getPlotId())) {
+                    List<ImageEntity> images = imageRepository
+                            .findByPlotIdAndSceneNumberOrderByFrameTypeAsc(
+                                    plot.getPlotId(), sceneNumber);
+
+                    String firstFrameUrl = images.stream()
+                            .filter(img -> "FIRST".equals(img.getFrameType()))
+                            .map(ImageEntity::getImageUrl)
+                            .filter(url -> url != null && !url.isBlank())
+                            .findFirst().orElse(null);
+
+                    String lastFrameUrl = images.stream()
+                            .filter(img -> "LAST".equals(img.getFrameType()))
+                            .map(ImageEntity::getImageUrl)
+                            .filter(url -> url != null && !url.isBlank())
+                            .findFirst().orElse(null);
+
+                    String combinedPrompt = findSceneVideo(plot.getPlotId(), sceneNumber)
+                            .map(VideoEntity::getVideoPrompt)
+                            .orElse(null);
+
+                    sceneInfos.add(new VideoSceneInfoResponse(
+                            sceneNumber, null, firstFrameUrl, lastFrameUrl, combinedPrompt));
+                }
+            }
+        }
+
+        // 씬 번호 오름차순 정렬
+        sceneInfos.sort(Comparator.comparing(VideoSceneInfoResponse::sceneNumber,
+                Comparator.nullsLast(Comparator.naturalOrder())));
+
+        return new VideoPageInitResponse(projectId, sceneInfos);
     }
 
     public ProjectInfoResponse getProjectInfo(String projectId, String userId) {
@@ -320,5 +517,46 @@ public class ContentQueryService {
                 video.getVideoUrl(),
                 video.getStatus(),
                 video.getCreatedAt());
+    }
+
+    /**
+     * PlotEntity.scenesJson(JSON 문자열)을 SceneDto 목록으로 역직렬화한다.
+     *
+     * <p>scenesJson이 null이거나 비어 있으면 빈 리스트를 반환한다.
+     * 역직렬화 실패 시 경고 로그를 남기고 빈 리스트를 반환한다.</p>
+     *
+     * @param scenesJson JSON 배열 문자열 (null 허용)
+     * @return 씬 DTO 목록 (빈 리스트 가능)
+     */
+    private List<SceneDto> parseScenes(String scenesJson) {
+        if (scenesJson == null || scenesJson.isBlank()) {
+            return List.of();
+        }
+        try {
+            return objectMapper.readValue(scenesJson, new TypeReference<List<SceneDto>>() {});
+        } catch (Exception e) {
+            log.warn("scenesJson 파싱 실패 (빈 리스트 반환): {}", e.getMessage());
+            return List.of();
+        }
+    }
+
+    /**
+     * 첫 프레임 프롬프트와 마지막 프레임 프롬프트를 합산하여 통합 프롬프트를 구성한다.
+     *
+     * @param firstFramePrompt 첫 프레임 이미지 생성 프롬프트 (null 허용)
+     * @param lastFramePrompt  마지막 프레임 이미지 생성 프롬프트 (null 허용)
+     * @return 합산 프롬프트 (양쪽 모두 null이면 null)
+     */
+    private String buildCombinedPrompt(String firstFramePrompt, String lastFramePrompt) {
+        if (firstFramePrompt == null && lastFramePrompt == null) {
+            return null;
+        }
+        if (firstFramePrompt == null) {
+            return lastFramePrompt;
+        }
+        if (lastFramePrompt == null) {
+            return firstFramePrompt;
+        }
+        return firstFramePrompt + " " + lastFramePrompt;
     }
 }

--- a/src/main/java/com/estaid/plot/PlotController.java
+++ b/src/main/java/com/estaid/plot/PlotController.java
@@ -1,8 +1,12 @@
 package com.estaid.plot;
 
 import com.estaid.common.response.ApiResponse;
+import com.estaid.plot.dto.FrameRegenerateRequest;
+import com.estaid.plot.dto.FrameRegenerateResponse;
 import com.estaid.plot.dto.PlotCreateRequest;
+import com.estaid.plot.dto.PlotGenerateRequest;
 import com.estaid.plot.dto.PlotResponse;
+import com.estaid.plot.dto.SceneBatchSaveRequest;
 import com.estaid.plot.dto.SceneUpdateRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -15,25 +19,36 @@ import java.util.List;
 /**
  * 플롯 REST 컨트롤러
  *
- * <p>기본 경로: {@code /api/plots}</p>
+ * <p>기존 경로: {@code /api/plots} (하위 호환 유지)</p>
  *
  * <ul>
- *   <li>POST   /api/plots                                  - 플롯 생성 (Claude AI 씬 자동 생성)</li>
- *   <li>GET    /api/plots?projectId={id}                   - 프로젝트 내 플롯 목록 조회</li>
- *   <li>GET    /api/plots/{plotId}                         - 플롯 단건 조회</li>
- *   <li>PUT    /api/plots/{plotId}/scenes/{sceneNumber}    - 특정 씬 내용 수정</li>
- *   <li>DELETE /api/plots/{plotId}                         - 플롯 삭제</li>
+ *   <li>POST   /api/plots                                      - 플롯 생성 (기존, 하위 호환)</li>
+ *   <li>GET    /api/plots?projectId={id}                       - 프로젝트 내 플롯 목록 조회</li>
+ *   <li>GET    /api/plots/{plotId}                             - 플롯 단건 조회</li>
+ *   <li>PUT    /api/plots/{plotId}/scenes/{sceneNumber}        - 특정 씬 단건 수정 (하위 호환)</li>
+ *   <li>DELETE /api/plots/{plotId}                             - 플롯 삭제</li>
+ * </ul>
+ *
+ * <p>신규 경로: {@code /api/projects}</p>
+ *
+ * <ul>
+ *   <li>POST /api/projects/plots/generate                      - AI 스토리보드 자동 생성 (한 프로젝트당 1회)</li>
+ *   <li>PUT  /api/projects/{projectId}/plots/scenes            - 전체 씬 배치 저장 (다음 버튼)</li>
+ *   <li>POST /api/projects/plots/frames/regenerate             - 특정 프레임 이미지 재생성</li>
  * </ul>
  */
 @RestController
-@RequestMapping("/api/plots")
 @RequiredArgsConstructor
 public class PlotController {
 
     private final PlotService plotService;
 
+    // ─────────────────────────────────────────
+    // 기존 API (하위 호환 유지)
+    // ─────────────────────────────────────────
+
     /**
-     * 플롯 생성 (Claude AI 씬 자동 생성)
+     * 플롯 생성 (기존 API, 하위 호환 유지)
      *
      * <p>Claude API를 호출하여 {@code sceneCount}개의 씬을 자동 생성한다.
      * Claude API 응답 대기 시간이 있어 최대 60초 소요될 수 있다.</p>
@@ -41,38 +56,96 @@ public class PlotController {
      * @param request 플롯 생성 요청 바디 (projectId, title, idea, sceneCount 등)
      * @return 201 Created + 생성된 플롯 정보 (씬 목록 포함)
      */
-    @PostMapping
+    @PostMapping("/api/plots")
     public ResponseEntity<ApiResponse<PlotResponse>> create(@Valid @RequestBody PlotCreateRequest request) {
         PlotResponse response = plotService.create(request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.ok("플롯이 생성되었습니다.", response));
     }
 
+    // ─────────────────────────────────────────
+    // 신규 API
+    // ─────────────────────────────────────────
+
     /**
-     * 프로젝트 내 플롯 목록 조회
+     * AI 스토리보드 자동 생성 (신규 — 한 프로젝트당 1번만 가능)
+     *
+     * <p>전체 줄거리를 입력받아 Claude AI가 sceneCount개의 씬을 자동 생성한다.
+     * 이미 플롯이 존재하면 409 Conflict를 반환한다.</p>
+     *
+     * <p>composition 필드는 Enum 10가지 값 중 하나로 반환된다.
+     * firstFrameImageUrl / lastFrameImageUrl은 생성 직후 null이며,
+     * {@code POST /api/projects/plots/frames/regenerate}로 개별 생성한다.</p>
+     *
+     * @param request 스토리보드 생성 요청 바디 (projectId, storyDescription, sceneCount, ratio)
+     * @return 201 Created + 생성된 플롯 정보 (씬 목록 포함)
+     */
+    @PostMapping("/api/projects/plots/generate")
+    public ResponseEntity<ApiResponse<PlotResponse>> generate(@Valid @RequestBody PlotGenerateRequest request) {
+        PlotResponse response = plotService.generate(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.ok("스토리보드가 생성되었습니다.", response));
+    }
+
+    /**
+     * 전체 씬 배치 저장 (다음 버튼 클릭 시 호출)
+     *
+     * <p>씬 만들기 페이지에서 사용자가 수정한 전체 씬 목록을 한 번에 저장한다.
+     * 기존 scenesJson을 요청 데이터로 완전히 교체한다.</p>
+     *
+     * @param projectId 프로젝트 UUID (경로 변수)
+     * @param request   씬 목록 배치 저장 요청 바디
+     * @return 200 OK
+     */
+    @PutMapping("/api/projects/{projectId}/plots/scenes")
+    public ResponseEntity<ApiResponse<Void>> saveScenesBatch(
+            @PathVariable String projectId,
+            @Valid @RequestBody SceneBatchSaveRequest request) {
+        plotService.saveScenesBatch(projectId, request);
+        return ResponseEntity.ok(ApiResponse.ok("씬이 저장되었습니다.", null));
+    }
+
+    /**
+     * 프레임 이미지 재생성
+     *
+     * <p>씬의 첫 프레임 또는 마지막 프레임 이미지를 FAL.ai로 재생성한다.
+     * 재생성 후 SceneDto의 imageUrl과 prompt가 업데이트된다.</p>
+     *
+     * @param request 프레임 재생성 요청 바디 (projectId, sceneNumber, firstOrLast, prompt)
+     * @return 200 OK + 재생성된 이미지 URL
+     */
+    @PostMapping("/api/projects/plots/frames/regenerate")
+    public ResponseEntity<ApiResponse<FrameRegenerateResponse>> regenerateFrame(
+            @Valid @RequestBody FrameRegenerateRequest request) {
+        FrameRegenerateResponse response = plotService.regenerateFrame(request);
+        return ResponseEntity.ok(ApiResponse.ok("프레임 이미지가 재생성되었습니다.", response));
+    }
+
+    /**
+     * 프로젝트 내 플롯 목록 조회 (기존 API, 하위 호환)
      *
      * @param projectId 조회할 프로젝트 UUID (쿼리 파라미터)
      * @return 200 OK + 플롯 목록 (씬 목록 포함)
      */
-    @GetMapping
+    @GetMapping("/api/plots")
     public ResponseEntity<ApiResponse<List<PlotResponse>>> findAllByProject(
             @RequestParam String projectId) {
         return ResponseEntity.ok(ApiResponse.ok(plotService.findAllByProject(projectId)));
     }
 
     /**
-     * 플롯 단건 조회
+     * 플롯 단건 조회 (기존 API, 하위 호환)
      *
      * @param plotId 조회할 플롯 UUID
      * @return 200 OK + 플롯 정보 (씬 목록 포함)
      */
-    @GetMapping("/{plotId}")
+    @GetMapping("/api/plots/{plotId}")
     public ResponseEntity<ApiResponse<PlotResponse>> findById(@PathVariable String plotId) {
         return ResponseEntity.ok(ApiResponse.ok(plotService.findById(plotId)));
     }
 
     /**
-     * 특정 씬 내용 수정 (사용자 직접 편집)
+     * 특정 씬 단건 수정 (기존 API, 하위 호환)
      *
      * <p>Claude가 생성한 씬 내용을 프론트엔드 표(테이블)에서 수정한 후 호출한다.
      * 수정된 씬은 DB의 {@code scenes_json}에 반영된다.</p>
@@ -82,7 +155,7 @@ public class PlotController {
      * @param request     씬 수정 요청 바디
      * @return 200 OK + 수정된 플롯 전체 정보 (씬 목록 포함)
      */
-    @PutMapping("/{plotId}/scenes/{sceneNumber}")
+    @PutMapping("/api/plots/{plotId}/scenes/{sceneNumber}")
     public ResponseEntity<ApiResponse<PlotResponse>> updateScene(
             @PathVariable String plotId,
             @PathVariable int sceneNumber,
@@ -92,14 +165,14 @@ public class PlotController {
     }
 
     /**
-     * 플롯 삭제
+     * 플롯 삭제 (기존 API, 하위 호환)
      *
      * <p>연결된 이미지·영상도 CASCADE 삭제된다.</p>
      *
      * @param plotId 삭제할 플롯 UUID
      * @return 200 OK
      */
-    @DeleteMapping("/{plotId}")
+    @DeleteMapping("/api/plots/{plotId}")
     public ResponseEntity<ApiResponse<Void>> delete(@PathVariable String plotId) {
         plotService.delete(plotId);
         return ResponseEntity.ok(ApiResponse.ok("플롯이 삭제되었습니다.", null));

--- a/src/main/java/com/estaid/plot/PlotService.java
+++ b/src/main/java/com/estaid/plot/PlotService.java
@@ -4,8 +4,13 @@ import com.estaid.character.Character;
 import com.estaid.character.CharacterRepository;
 import com.estaid.common.exception.BusinessException;
 import com.estaid.common.service.ClaudeService;
+import com.estaid.common.service.FalAiService;
+import com.estaid.plot.dto.FrameRegenerateRequest;
+import com.estaid.plot.dto.FrameRegenerateResponse;
 import com.estaid.plot.dto.PlotCreateRequest;
+import com.estaid.plot.dto.PlotGenerateRequest;
 import com.estaid.plot.dto.PlotResponse;
+import com.estaid.plot.dto.SceneBatchSaveRequest;
 import com.estaid.plot.dto.SceneDto;
 import com.estaid.plot.dto.SceneUpdateRequest;
 import com.estaid.project.Project;
@@ -44,10 +49,11 @@ public class PlotService {
     private final ProjectRepository projectRepository;
     private final CharacterRepository characterRepository;
     private final ClaudeService claudeService;
+    private final FalAiService falAiService;
     private final ObjectMapper objectMapper;
 
     /**
-     * 플롯 생성 (Claude API 씬 자동 생성 포함)
+     * 플롯 생성 (기존 API, 하위 호환 유지)
      *
      * <p>처리 흐름:</p>
      * <pre>
@@ -76,11 +82,9 @@ public class PlotService {
         // 3. Claude API 호출 → 씬 목록 생성
         int sceneCount = request.getSceneCount() != null ? request.getSceneCount() : 5;
         List<SceneDto> scenes = claudeService.generateScenes(
-                request.getTitle(),
                 request.getIdea(),
                 sceneCount,
-                request.getArtStyle(),
-                character
+                null
         );
 
         // 4. 씬 목록 JSON 직렬화
@@ -99,6 +103,146 @@ public class PlotService {
         Plot saved = plotRepository.save(plot);
         log.info("플롯 생성 완료: plotId={}, title={}, sceneCount={}", saved.getPlotId(), saved.getTitle(), scenes.size());
         return PlotResponse.from(saved, scenes);
+    }
+
+    /**
+     * AI 스토리보드 자동 생성 (신규 API)
+     *
+     * <p>프론트 요청 기반의 신규 엔드포인트용 메서드.
+     * 한 프로젝트당 1번만 생성 가능하며, 이미 플롯이 존재하면 409 Conflict를 반환한다.</p>
+     *
+     * <p>처리 흐름:</p>
+     * <pre>
+     *   1. projectId로 프로젝트 조회 (없으면 404)
+     *   2. 해당 프로젝트에 이미 플롯이 있으면 409 Conflict
+     *   3. Claude API 호출 → sceneCount개의 씬 JSON 생성
+     *      (composition Enum, majorStory, backgroundDetail 포함)
+     *   4. 씬 목록 JSON 직렬화 후 Plot 저장
+     *   5. PlotResponse 반환 (firstFrameImageUrl/lastFrameImageUrl은 null)
+     * </pre>
+     *
+     * @param request 스토리보드 생성 요청 DTO (projectId, storyDescription, sceneCount, ratio)
+     * @return 생성된 플롯 응답 DTO (씬 목록 포함, 프레임 이미지 URL은 null)
+     * @throws BusinessException 프로젝트 미존재(404), 이미 플롯 존재(409), Claude API 실패(502)
+     */
+    @Transactional
+    public PlotResponse generate(PlotGenerateRequest request) {
+        // 1. 프로젝트 조회
+        Project project = getProjectOrThrow(request.getProjectId());
+
+        // 2. 한 프로젝트당 1번 제한: 이미 플롯이 있으면 409 반환
+        List<Plot> existing = plotRepository.findByProject_ProjectId(request.getProjectId());
+        if (!existing.isEmpty()) {
+            throw new BusinessException(
+                    "이미 스토리보드가 생성된 프로젝트입니다. 프로젝트당 1번만 생성 가능합니다.",
+                    HttpStatus.CONFLICT);
+        }
+
+        // 3. Claude API 호출 → 씬 목록 생성
+        int sceneCount = request.getSceneCount() != null ? request.getSceneCount() : 4;
+        List<SceneDto> scenes = claudeService.generateScenes(
+                request.getStoryDescription(),
+                sceneCount,
+                request.getRatio()
+        );
+
+        // 4. 씬 목록 JSON 직렬화
+        String scenesJson = serializeScenes(scenes);
+
+        // 5. Plot 엔티티 저장 (title은 storyDescription의 앞 50자로 대체)
+        String title = request.getStoryDescription().length() > 50
+                ? request.getStoryDescription().substring(0, 50)
+                : request.getStoryDescription();
+
+        Plot plot = Plot.builder()
+                .project(project)
+                .title(title)
+                .idea(request.getStoryDescription())
+                .scenesJson(scenesJson)
+                .build();
+
+        Plot saved = plotRepository.save(plot);
+        log.info("스토리보드 자동 생성 완료: plotId={}, projectId={}, sceneCount={}",
+                saved.getPlotId(), request.getProjectId(), scenes.size());
+        return PlotResponse.from(saved, scenes);
+    }
+
+    /**
+     * 전체 씬 배치 저장 (다음 버튼 클릭 시 호출)
+     *
+     * <p>사용자가 씬 만들기 페이지에서 수정한 전체 씬 목록을 한 번에 저장한다.
+     * 기존 scenesJson을 요청 데이터로 완전히 교체한다.</p>
+     *
+     * @param projectId 프로젝트 UUID
+     * @param request   씬 배치 저장 요청 DTO (씬 목록)
+     * @throws BusinessException 프로젝트 미존재(404), 플롯 미존재(404)
+     */
+    @Transactional
+    public void saveScenesBatch(String projectId, SceneBatchSaveRequest request) {
+        // 1. 해당 프로젝트의 플롯 조회
+        List<Plot> plots = plotRepository.findByProject_ProjectId(projectId);
+        if (plots.isEmpty()) {
+            throw new BusinessException(
+                    "플롯을 찾을 수 없습니다. projectId=" + projectId, HttpStatus.NOT_FOUND);
+        }
+
+        // 2. 첫 번째 플롯(프로젝트당 1개)의 scenesJson을 요청 데이터로 교체
+        Plot plot = plots.get(0);
+        String scenesJson = serializeScenes(request.getScenes());
+        plot.setScenesJson(scenesJson);
+
+        log.info("씬 배치 저장 완료: plotId={}, projectId={}, sceneCount={}",
+                plot.getPlotId(), projectId, request.getScenes().size());
+    }
+
+    /**
+     * 프레임 이미지 재생성
+     *
+     * <p>씬의 첫 프레임 또는 마지막 프레임 이미지를 FAL.ai로 재생성한다.
+     * 재생성 후 SceneDto의 firstFrameImageUrl 또는 lastFrameImageUrl을 업데이트한다.</p>
+     *
+     * @param request 프레임 재생성 요청 DTO (projectId, sceneNumber, firstOrLast, prompt)
+     * @return 재생성된 이미지 URL
+     * @throws BusinessException 프로젝트·플롯·씬 미존재(404), FAL.ai 실패(502)
+     */
+    @Transactional
+    public FrameRegenerateResponse regenerateFrame(FrameRegenerateRequest request) {
+        // 1. 해당 프로젝트의 플롯 조회
+        List<Plot> plots = plotRepository.findByProject_ProjectId(request.getProjectId());
+        if (plots.isEmpty()) {
+            throw new BusinessException(
+                    "플롯을 찾을 수 없습니다. projectId=" + request.getProjectId(), HttpStatus.NOT_FOUND);
+        }
+
+        Plot plot = plots.get(0);
+
+        // 2. 씬 목록에서 해당 씬 번호 찾기
+        List<SceneDto> scenes = deserializeScenes(plot.getScenesJson());
+        SceneDto target = scenes.stream()
+                .filter(s -> s.getSceneNumber() == request.getSceneNumber())
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(
+                        "씬 번호를 찾을 수 없습니다. sceneNumber=" + request.getSceneNumber(),
+                        HttpStatus.NOT_FOUND));
+
+        // 3. FAL.ai로 이미지 재생성 (referenceImageUrl 없이 프롬프트만 사용)
+        String imageUrl = falAiService.generateImageSync(null, request.getPrompt());
+
+        // 4. 해당 프레임 URL 업데이트 후 scenesJson 저장
+        boolean isFirst = "FIRST".equalsIgnoreCase(request.getFirstOrLast());
+        if (isFirst) {
+            target.setFirstFrameImageUrl(imageUrl);
+            target.setFirstFramePrompt(request.getPrompt()); // 프롬프트도 업데이트
+        } else {
+            target.setLastFrameImageUrl(imageUrl);
+            target.setLastFramePrompt(request.getPrompt()); // 프롬프트도 업데이트
+        }
+
+        plot.setScenesJson(serializeScenes(scenes));
+        log.info("프레임 재생성 완료: plotId={}, sceneNumber={}, firstOrLast={}, imageUrl={}",
+                plot.getPlotId(), request.getSceneNumber(), request.getFirstOrLast(), imageUrl);
+
+        return new FrameRegenerateResponse(imageUrl);
     }
 
     /**
@@ -134,14 +278,17 @@ public class PlotService {
                 .orElseThrow(() -> new BusinessException(
                         "씬 번호를 찾을 수 없습니다. sceneNumber=" + sceneNumber, HttpStatus.NOT_FOUND));
 
-        // 4. 씬 내용 수정
+        // 4. 씬 내용 수정 (null인 필드도 그대로 반영되므로 클라이언트가 기존 값 포함하여 전송해야 함)
         target.setCharacters(request.getCharacters());
         target.setComposition(request.getComposition());
         target.setBackground(request.getBackground());
+        target.setBackgroundDetail(request.getBackgroundDetail());
         target.setLighting(request.getLighting());
-        target.setMainStory(request.getMainStory());
+        target.setMajorStory(request.getMajorStory());
         target.setFirstFramePrompt(request.getFirstFramePrompt());
+        target.setFirstFrameImageUrl(request.getFirstFrameImageUrl());
         target.setLastFramePrompt(request.getLastFramePrompt());
+        target.setLastFrameImageUrl(request.getLastFrameImageUrl());
 
         // 5. 재직렬화 후 저장
         plot.setScenesJson(serializeScenes(scenes));

--- a/src/main/java/com/estaid/plot/dto/FrameRegenerateRequest.java
+++ b/src/main/java/com/estaid/plot/dto/FrameRegenerateRequest.java
@@ -1,0 +1,48 @@
+package com.estaid.plot.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+/**
+ * 프레임 이미지 재생성 요청 DTO
+ *
+ * <p>씬의 첫 프레임 또는 마지막 프레임 이미지를 FAL.ai로 재생성한다.
+ * 사용자가 프롬프트를 수정하거나 이미지가 마음에 들지 않을 때 호출한다.</p>
+ *
+ * <p>엔드포인트: {@code POST /api/projects/plots/frames/regenerate}</p>
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FrameRegenerateRequest {
+
+    /**
+     * 소속 프로젝트 UUID (필수)
+     * 해당 프로젝트의 플롯에서 씬을 찾는다.
+     */
+    @NotBlank(message = "프로젝트 ID는 필수입니다.")
+    private String projectId;
+
+    /**
+     * 재생성할 씬 번호 (필수, 1 이상)
+     */
+    @NotNull(message = "씬 번호는 필수입니다.")
+    @Min(value = 1, message = "씬 번호는 1 이상이어야 합니다.")
+    private Integer sceneNumber;
+
+    /**
+     * 재생성할 프레임 위치 (필수)
+     * "FIRST" = 시작 프레임, "LAST" = 끝 프레임
+     */
+    @NotBlank(message = "firstOrLast는 필수입니다. (FIRST 또는 LAST)")
+    private String firstOrLast;
+
+    /**
+     * 이미지 생성에 사용할 영어 프롬프트 (필수)
+     * 사용자가 수정하거나 기존 프롬프트를 그대로 전달한다.
+     */
+    @NotBlank(message = "프롬프트는 필수입니다.")
+    private String prompt;
+}

--- a/src/main/java/com/estaid/plot/dto/FrameRegenerateResponse.java
+++ b/src/main/java/com/estaid/plot/dto/FrameRegenerateResponse.java
@@ -1,0 +1,19 @@
+package com.estaid.plot.dto;
+
+import lombok.*;
+
+/**
+ * 프레임 이미지 재생성 응답 DTO
+ *
+ * <p>FAL.ai가 생성한 프레임 이미지 URL을 반환한다.</p>
+ */
+@Getter
+@AllArgsConstructor
+public class FrameRegenerateResponse {
+
+    /**
+     * 재생성된 프레임 이미지 URL
+     * FAL.ai FLUX Kontext가 생성한 이미지의 공개 URL이다.
+     */
+    private String imageUrl;
+}

--- a/src/main/java/com/estaid/plot/dto/PlotGenerateRequest.java
+++ b/src/main/java/com/estaid/plot/dto/PlotGenerateRequest.java
@@ -1,0 +1,48 @@
+package com.estaid.plot.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+/**
+ * AI 스토리보드 자동 생성 요청 DTO
+ *
+ * <p>사용자가 전체 줄거리를 입력하면 Claude AI가 sceneCount개의 씬을 자동 생성한다.
+ * 한 프로젝트당 1번만 생성 가능하며, 이미 플롯이 존재하면 409 Conflict를 반환한다.</p>
+ *
+ * <p>엔드포인트: {@code POST /api/projects/plots/generate}</p>
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlotGenerateRequest {
+
+    /**
+     * 소속 프로젝트 UUID (필수)
+     * 해당 프로젝트 아래에 플롯이 생성된다.
+     */
+    @NotBlank(message = "프로젝트 ID는 필수입니다.")
+    private String projectId;
+
+    /**
+     * 전체 줄거리 텍스트 (필수)
+     * Claude AI 씬 생성 프롬프트의 핵심 입력값이다.
+     * 예: "주인공이 도심 폐허에서 거대 괴물과 맞닥뜨려 싸우는 이야기"
+     */
+    @NotBlank(message = "스토리 설명은 필수입니다.")
+    private String storyDescription;
+
+    /**
+     * 생성할 씬 수 (선택, 기본값 4, 최소 1 ~ 최대 10)
+     * Claude API 호출 시 이 수만큼의 씬 JSON을 생성하도록 지시한다.
+     */
+    @Min(value = 1, message = "씬 수는 1 이상이어야 합니다.")
+    @Max(value = 10, message = "씬 수는 10 이하이어야 합니다.")
+    private Integer sceneCount = 4;
+
+    /**
+     * 영상 비율 (선택)
+     * 씬 구성에 참고용으로 전달된다.
+     * 예: "16:9", "9:16", "1:1", "4:3"
+     */
+    private String ratio;
+}

--- a/src/main/java/com/estaid/plot/dto/SceneBatchSaveRequest.java
+++ b/src/main/java/com/estaid/plot/dto/SceneBatchSaveRequest.java
@@ -1,0 +1,30 @@
+package com.estaid.plot.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.util.List;
+
+/**
+ * 전체 씬 배치 저장 요청 DTO
+ *
+ * <p>씬 만들기 페이지에서 사용자가 수정한 전체 씬 목록을 한 번에 저장한다.
+ * "다음" 버튼 클릭 시 호출되며, 기존 scenesJson을 전체 교체한다.</p>
+ *
+ * <p>엔드포인트: {@code PUT /api/projects/{projectId}/plots/scenes}</p>
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SceneBatchSaveRequest {
+
+    /**
+     * 저장할 씬 목록 (필수)
+     * sceneNumber 기준으로 기존 씬을 교체한다.
+     * 2.1 AI 스토리보드 생성 응답(SceneDto)과 동일한 구조다.
+     */
+    @NotNull(message = "씬 목록은 필수입니다.")
+    @Valid
+    private List<SceneDto> scenes;
+}

--- a/src/main/java/com/estaid/plot/dto/SceneDto.java
+++ b/src/main/java/com/estaid/plot/dto/SceneDto.java
@@ -12,15 +12,32 @@ import lombok.*;
  *
  * <p>각 씬은 영상 제작에 필요한 모든 정보를 포함한다:</p>
  * <ul>
- *   <li>sceneNumber  - 씬 순서 (1부터 시작)</li>
- *   <li>title        - 씬 제목</li>
- *   <li>characters   - 등장인물</li>
- *   <li>composition  - 카메라 구도 (ex. wide shot, close-up)</li>
- *   <li>background   - 배경 묘사</li>
- *   <li>lighting     - 조명·분위기</li>
- *   <li>mainStory    - 주요 스토리 (2~3문장)</li>
+ *   <li>sceneNumber       - 씬 순서 (1부터 시작)</li>
+ *   <li>title             - 씬 제목</li>
+ *   <li>characters        - 등장인물</li>
+ *   <li>composition       - 카메라 구도 Enum (10가지 값 중 하나)</li>
+ *   <li>background        - 배경 장소 이름 (1.1 자산 생성에서 만든 배경 이름)</li>
+ *   <li>backgroundDetail  - 배경 상세 묘사 (AI가 생성한 영어 이미지 생성용 텍스트)</li>
+ *   <li>lighting          - 조명·분위기</li>
+ *   <li>majorStory        - 씬에 대한 구체적 설명/사건 (2~3문장)</li>
  *   <li>firstFramePrompt  - 첫 프레임 이미지 생성 영어 프롬프트</li>
+ *   <li>firstFrameImageUrl - 첫 프레임 이미지 URL (비동기 생성 전 null)</li>
  *   <li>lastFramePrompt   - 마지막 프레임 이미지 생성 영어 프롬프트</li>
+ *   <li>lastFrameImageUrl  - 마지막 프레임 이미지 URL (비동기 생성 전 null)</li>
+ * </ul>
+ *
+ * <p>composition 허용 값 (Claude가 반드시 아래 10가지 중 하나만 반환):</p>
+ * <ul>
+ *   <li>EXTREME_CLOSEUP   - 극도의 클로즈업</li>
+ *   <li>HIGH_ANGLE        - 위에서 아래를 보는 부감</li>
+ *   <li>LOW_ANGLE         - 아래에서 위를 보는 앙굴</li>
+ *   <li>MEDIUM_SHOT       - 인물의 상반신 위주</li>
+ *   <li>OVER_THE_SHOULDER - 어깨 너머 샷</li>
+ *   <li>TWO_SHOT          - 두 명의 인물이 등장하는 샷</li>
+ *   <li>WIDE_SHOT         - 먼 거리에서 배경과 함께 보여주는 샷</li>
+ *   <li>BIRD_EYE_VIEW     - 아주 높은 곳에서 수직으로 내려다보는 샷</li>
+ *   <li>CLOSEUP           - 인물의 얼굴에 집중</li>
+ *   <li>DUTCH_ANGLE       - 화면을 비스듬히 기울인 불안정한 느낌의 샷</li>
  * </ul>
  */
 @Getter
@@ -40,17 +57,35 @@ public class SceneDto {
     /** 등장인물 (예: "주인공, 괴물") */
     private String characters;
 
-    /** 카메라 구도 (예: "wide cinematic shot", "close-up", "low angle") */
+    /**
+     * 카메라 구도 — Claude가 반드시 아래 10가지 Enum 값 중 하나만 반환한다.
+     * EXTREME_CLOSEUP / HIGH_ANGLE / LOW_ANGLE / MEDIUM_SHOT / OVER_THE_SHOULDER
+     * TWO_SHOT / WIDE_SHOT / BIRD_EYE_VIEW / CLOSEUP / DUTCH_ANGLE
+     */
     private String composition;
 
-    /** 배경 묘사 (예: "폐허가 된 도심, 먼지와 잔해") */
+    /**
+     * 배경 장소 이름 (1~3단어)
+     * 예: "어두운 숲", "도심 옥상", "폐허가 된 성"
+     * 1.1 자산 생성에서 만든 배경 자산의 이름과 연결된다.
+     */
     private String background;
+
+    /**
+     * 배경 상세 묘사 (AI 생성, 영어)
+     * 이미지 생성 프롬프트에 활용되는 구체적인 배경 묘사 텍스트.
+     * 예: "Dense pine forest with moonlight filtering through the mist"
+     */
+    private String backgroundDetail;
 
     /** 조명·분위기 (예: "dark storm clouds, dramatic lightning") */
     private String lighting;
 
-    /** 주요 스토리 요약 (2~3문장) */
-    private String mainStory;
+    /**
+     * 씬에 대한 구체적 설명/사건 (2~3문장)
+     * 기존 mainStory 필드를 대체한다.
+     */
+    private String majorStory;
 
     /**
      * 첫 프레임 이미지 생성 영어 프롬프트
@@ -59,8 +94,20 @@ public class SceneDto {
     private String firstFramePrompt;
 
     /**
+     * 첫 프레임 이미지 URL
+     * 플롯 생성 직후에는 null이며, 프레임 재생성 API(POST .../frames/regenerate)로 채워진다.
+     */
+    private String firstFrameImageUrl;
+
+    /**
      * 마지막 프레임 이미지 생성 영어 프롬프트
      * FAL.ai FLUX Kontext 호출 시 마지막 프레임 이미지 생성에 사용된다.
      */
     private String lastFramePrompt;
+
+    /**
+     * 마지막 프레임 이미지 URL
+     * 플롯 생성 직후에는 null이며, 프레임 재생성 API(POST .../frames/regenerate)로 채워진다.
+     */
+    private String lastFrameImageUrl;
 }

--- a/src/main/java/com/estaid/plot/dto/SceneUpdateRequest.java
+++ b/src/main/java/com/estaid/plot/dto/SceneUpdateRequest.java
@@ -27,21 +27,34 @@ public class SceneUpdateRequest {
     /** 등장인물 (예: "주인공 단독", "주인공, 괴물") */
     private String characters;
 
-    /** 카메라 구도 (예: "low angle shot", "wide cinematic shot") */
+    /**
+     * 카메라 구도 — Enum 10가지 값 중 하나.
+     * EXTREME_CLOSEUP / HIGH_ANGLE / LOW_ANGLE / MEDIUM_SHOT / OVER_THE_SHOULDER /
+     * TWO_SHOT / WIDE_SHOT / BIRD_EYE_VIEW / CLOSEUP / DUTCH_ANGLE
+     */
     private String composition;
 
-    /** 배경 묘사 (예: "벚꽃 공원, 봄날 오후") */
+    /** 배경 장소 이름 (1~3단어, 예: "벚꽃 공원") */
     private String background;
+
+    /** 배경 상세 묘사 (영어, 이미지 생성 프롬프트용) */
+    private String backgroundDetail;
 
     /** 조명·분위기 (예: "오후 햇살, 따뜻한 오렌지 톤") */
     private String lighting;
 
-    /** 수정된 주요 스토리 (2~3문장) */
-    private String mainStory;
+    /** 씬에 대한 구체적 설명/사건 (2~3문장, 기존 mainStory 대체) */
+    private String majorStory;
 
     /** 수정된 첫 프레임 영어 이미지 생성 프롬프트 */
     private String firstFramePrompt;
 
+    /** 수정된 첫 프레임 이미지 URL (재생성 후 업데이트) */
+    private String firstFrameImageUrl;
+
     /** 수정된 마지막 프레임 영어 이미지 생성 프롬프트 */
     private String lastFramePrompt;
+
+    /** 수정된 마지막 프레임 이미지 URL (재생성 후 업데이트) */
+    private String lastFrameImageUrl;
 }

--- a/src/main/java/com/estaid/video/VideoService.java
+++ b/src/main/java/com/estaid/video/VideoService.java
@@ -62,41 +62,85 @@ public class VideoService {
      * <p>영상 엔티티를 즉시 PENDING 상태로 저장하고,
      * FAL.ai API 호출은 비동기(@Async)로 처리한다.</p>
      *
-     * @param request 영상 생성 요청 DTO (plotId, sceneNumber, firstImageId, lastImageId)
-     * @return 생성된 Video 응답 DTO (status=PENDING)
-     * @throws BusinessException 플롯·씬·이미지 미존재(404), 이미지 미완성(400) 시
+     * <p>두 가지 방식을 지원한다:</p>
+     * <ul>
+     *   <li>방식 A (신규): projectId + sceneNumber + prompt → SceneDto URL 사용, 프롬프트 직접 지정</li>
+     *   <li>방식 B (기존): plotId + sceneNumber + firstImageId + lastImageId → Image 엔티티 참조</li>
+     * </ul>
+     *
+     * @param request 영상 생성 요청 DTO
+     * @return 생성된 Video 응답 DTO (status=PENDING, thumbnail 포함)
+     * @throws BusinessException 플롯·씬·이미지 미존재(404), 이미지 미완성(400),
+     *                           plotId/projectId 미제공(400) 시
      */
     @Transactional
     public VideoResponse generate(VideoGenerateRequest request) {
-        // 1. 플롯 조회
-        Plot plot = getPlotOrThrow(request.getPlotId());
+        // 1. 플롯 조회 — projectId 또는 plotId 중 하나 필수
+        Plot plot;
+        if (request.getProjectId() != null && !request.getProjectId().isBlank()) {
+            // [방식 A] projectId로 플롯 조회 (프로젝트당 1개 제한)
+            List<Plot> projectPlots = plotRepository.findByProject_ProjectId(request.getProjectId());
+            if (projectPlots.isEmpty()) {
+                throw new BusinessException(
+                        "해당 프로젝트의 플롯이 없습니다. projectId=" + request.getProjectId(),
+                        HttpStatus.NOT_FOUND);
+            }
+            plot = projectPlots.get(0); // 프로젝트당 1개 플롯
+        } else if (request.getPlotId() != null && !request.getPlotId().isBlank()) {
+            // [방식 B] plotId로 직접 조회
+            plot = getPlotOrThrow(request.getPlotId());
+        } else {
+            throw new BusinessException("projectId 또는 plotId 중 하나는 필수입니다.", HttpStatus.BAD_REQUEST);
+        }
 
-        // 2. 첫/마지막 프레임 이미지 조회 및 COMPLETED 검증
-        Image firstImage = getCompletedImageOrThrow(request.getFirstImageId(), "첫 프레임");
-        Image lastImage = getCompletedImageOrThrow(request.getLastImageId(), "마지막 프레임");
-
-        // 3. 씬 목록 역직렬화 → 해당 씬 추출
-        List<SceneDto> scenes = deserializeScenes(plot.getScenesJson());
-        SceneDto scene = scenes.stream()
+        // 2. 씬 목록 역직렬화 → 해당 씬 추출
+        List<SceneDto> sceneList = deserializeScenes(plot.getScenesJson());
+        SceneDto scene = sceneList.stream()
                 .filter(s -> s.getSceneNumber() == request.getSceneNumber())
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(
                         "씬 번호를 찾을 수 없습니다. sceneNumber=" + request.getSceneNumber(),
                         HttpStatus.NOT_FOUND));
 
-        // 4. Claude API → 영상 프롬프트 자동 생성
-        String videoPrompt;
-        try {
-            videoPrompt = claudeService.generateVideoPrompt(scene, plot.getArtStyle());
-        } catch (Exception e) {
-            log.warn("Claude 영상 프롬프트 생성 실패, 기본 프롬프트 사용: {}", e.getMessage());
-            // 실패 시 씬의 mainStory를 기본 프롬프트로 사용
-            videoPrompt = buildFallbackPrompt(scene, plot.getArtStyle());
+        // 3. 프레임 이미지 URL + Image 엔티티 결정
+        String firstFrameUrl;
+        String lastFrameUrl;
+        Image firstImage = null;
+        Image lastImage = null;
+
+        if (request.getFirstImageId() != null && !request.getFirstImageId().isBlank()) {
+            // [방식 B] Image 엔티티 조회 및 COMPLETED 검증
+            firstImage = getCompletedImageOrThrow(request.getFirstImageId(), "첫 프레임");
+            lastImage = getCompletedImageOrThrow(request.getLastImageId(), "마지막 프레임");
+            firstFrameUrl = firstImage.getImageUrl();
+            lastFrameUrl = lastImage.getImageUrl();
+        } else {
+            // [방식 A] SceneDto에서 URL 직접 추출
+            firstFrameUrl = scene.getFirstFrameImageUrl();
+            lastFrameUrl = scene.getLastFrameImageUrl();
+            if (firstFrameUrl == null || lastFrameUrl == null) {
+                throw new BusinessException(
+                        "첫/마지막 프레임 이미지가 아직 생성되지 않았습니다. "
+                        + "POST /api/projects/plots/frames/regenerate 로 먼저 프레임 이미지를 생성하세요.",
+                        HttpStatus.BAD_REQUEST);
+            }
         }
 
-        // 이미지 URL 추출 (LAZY 로딩 - 트랜잭션 내에서 접근)
-        String firstFrameUrl = firstImage.getImageUrl();
-        String lastFrameUrl = lastImage.getImageUrl();
+        // 4. 영상 프롬프트 결정
+        String videoPrompt;
+        if (request.getPrompt() != null && !request.getPrompt().isBlank()) {
+            // [방식 A] 사용자가 직접 제공한 프롬프트 사용
+            videoPrompt = request.getPrompt();
+            log.info("사용자 지정 영상 프롬프트 사용: sceneNumber={}", request.getSceneNumber());
+        } else {
+            // [방식 B] Claude API → 영상 프롬프트 자동 생성
+            try {
+                videoPrompt = claudeService.generateVideoPrompt(scene, plot.getArtStyle());
+            } catch (Exception e) {
+                log.warn("Claude 영상 프롬프트 생성 실패, 기본 프롬프트 사용: {}", e.getMessage());
+                videoPrompt = buildFallbackPrompt(scene, plot.getArtStyle());
+            }
+        }
 
         // 5. Video 엔티티 저장 (status=PENDING)
         Video video = Video.builder()
@@ -104,19 +148,22 @@ public class VideoService {
                 .sceneNumber(request.getSceneNumber())
                 .videoType(Video.VideoType.SCENE)
                 .videoPrompt(videoPrompt)
-                .firstImage(firstImage)
-                .lastImage(lastImage)
+                .firstImage(firstImage)   // 방식 A에서는 null
+                .lastImage(lastImage)     // 방식 A에서는 null
                 .status(Video.GenerationStatus.PENDING)
                 .build();
         Video saved = videoRepository.save(video);
         log.info("영상 엔티티 저장 완료: videoId={}, plotId={}, sceneNumber={}",
-                saved.getVideoId(), request.getPlotId(), request.getSceneNumber());
+                saved.getVideoId(), plot.getPlotId(), request.getSceneNumber());
 
         // 6. 비동기 FAL.ai 큐 제출 (@Async - 즉시 반환, 별도 스레드에서 처리)
         falAiService.processVideoGeneration(
                 saved.getVideoId(), firstFrameUrl, lastFrameUrl, videoPrompt);
 
-        return VideoResponse.from(saved);
+        // 7. 썸네일 = 씬의 첫 프레임 이미지 URL (Video 엔티티에 별도 컬럼 없음)
+        String thumbnail = firstFrameUrl;
+
+        return VideoResponse.from(saved, thumbnail);
     }
 
     /**
@@ -211,9 +258,19 @@ public class VideoService {
      * @param artStyle 화풍 설정 (null 허용)
      * @return 기본 영상 프롬프트
      */
+    /**
+     * Claude 프롬프트 생성 실패 시 사용하는 기본(폴백) 영상 프롬프트를 구성한다.
+     * 씬의 majorStory, composition, lighting, artStyle을 조합하여 영어 프롬프트를 반환한다.
+     *
+     * @param scene    씬 DTO
+     * @param artStyle 화풍 설정 (null 허용)
+     * @return 기본 영상 프롬프트
+     */
     private String buildFallbackPrompt(SceneDto scene, String artStyle) {
         StringBuilder sb = new StringBuilder();
-        sb.append(scene.getMainStory());
+        // majorStory가 있으면 사용, 없으면 빈 문자열로 시작
+        String story = scene.getMajorStory() != null ? scene.getMajorStory() : "";
+        sb.append(story);
         if (scene.getComposition() != null && !scene.getComposition().isBlank()) {
             sb.append(", ").append(scene.getComposition());
         }

--- a/src/main/java/com/estaid/video/dto/VideoGenerateRequest.java
+++ b/src/main/java/com/estaid/video/dto/VideoGenerateRequest.java
@@ -1,7 +1,6 @@
 package com.estaid.video.dto;
 
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,12 +9,26 @@ import lombok.Setter;
 /**
  * 영상 생성 요청 DTO
  *
- * <p>씬의 첫/마지막 프레임 이미지로 영상을 생성할 때 사용된다.
- * 두 이미지는 모두 {@code status=COMPLETED} 상태여야 한다.
- * Claude API가 씬 정보를 기반으로 영상 프롬프트를 자동 생성하며,
- * FAL.ai Wan 2.1 FLF2V 모델로 3~5초 영상이 생성된다.</p>
+ * <p>씬 영상을 FAL.ai Wan 2.1 FLF2V로 생성할 때 사용된다.</p>
  *
- * <p>사용 예시:</p>
+ * <p>두 가지 방식을 지원한다:</p>
+ *
+ * <p><b>방식 A — 신규 (projectId 기반)</b></p>
+ * <pre>
+ * POST /api/videos/generate
+ * {
+ *   "projectId": "uuid-of-project",
+ *   "sceneNumber": 1,
+ *   "prompt": "A slow cinematic dolly-in through a dark forest..."
+ * }
+ * </pre>
+ * <ul>
+ *   <li>projectId에서 플롯을 자동 조회</li>
+ *   <li>SceneDto의 firstFrameImageUrl / lastFrameImageUrl을 프레임 이미지로 사용</li>
+ *   <li>prompt를 영상 생성 프롬프트로 직접 사용 (Claude 자동 생성 없음)</li>
+ * </ul>
+ *
+ * <p><b>방식 B — 기존 (plotId 기반, 하위 호환)</b></p>
  * <pre>
  * POST /api/videos/generate
  * {
@@ -25,6 +38,10 @@ import lombok.Setter;
  *   "lastImageId": "uuid-of-last-frame-image"
  * }
  * </pre>
+ * <ul>
+ *   <li>firstImageId / lastImageId로 Image 엔티티를 직접 참조</li>
+ *   <li>Claude API가 씬 정보를 기반으로 영상 프롬프트를 자동 생성</li>
+ * </ul>
  */
 @Getter
 @Setter
@@ -32,31 +49,44 @@ import lombok.Setter;
 public class VideoGenerateRequest {
 
     /**
-     * 영상을 생성할 플롯의 UUID
-     * 씬 정보 조회 및 영상 프롬프트 생성에 사용된다.
+     * [신규 방식 A] 영상을 생성할 프로젝트 UUID
+     * plotId와 중 하나를 반드시 제공해야 한다.
+     * projectId가 있으면 해당 프로젝트의 플롯(1개)을 자동으로 조회한다.
      */
-    @NotBlank(message = "plotId는 필수입니다.")
+    private String projectId;
+
+    /**
+     * [기존 방식 B] 영상을 생성할 플롯의 UUID
+     * plotId 또는 projectId 중 하나를 반드시 제공해야 한다.
+     */
     private String plotId;
 
     /**
-     * 영상을 생성할 씬 번호 (1부터 시작)
-     * 씬 정보(mainStory, composition 등)가 Claude 프롬프트 생성에 사용된다.
+     * 영상을 생성할 씬 번호 (1부터 시작, 필수)
+     * 씬 정보(SceneDto) 조회에 사용된다.
      */
     @NotNull(message = "sceneNumber는 필수입니다.")
     @Min(value = 1, message = "sceneNumber는 1 이상이어야 합니다.")
     private Integer sceneNumber;
 
     /**
-     * 씬 첫 프레임 이미지 UUID (status=COMPLETED 이어야 함)
-     * FAL.ai의 first_frame_image_url로 전달된다.
+     * [신규 방식 A] 영상 생성 프롬프트 (사용자가 직접 제공)
+     * 제공 시 Claude 자동 생성을 건너뛰고 이 값을 직접 사용한다.
+     * 제공하지 않으면 Claude API가 씬 정보로 자동 생성한다.
      */
-    @NotBlank(message = "firstImageId는 필수입니다.")
+    private String prompt;
+
+    /**
+     * [기존 방식 B] 씬 첫 프레임 이미지 UUID (status=COMPLETED 이어야 함)
+     * FAL.ai의 first_frame_image_url로 전달된다.
+     * projectId 방식 사용 시 생략 가능 (SceneDto.firstFrameImageUrl 사용).
+     */
     private String firstImageId;
 
     /**
-     * 씬 마지막 프레임 이미지 UUID (status=COMPLETED 이어야 함)
+     * [기존 방식 B] 씬 마지막 프레임 이미지 UUID (status=COMPLETED 이어야 함)
      * FAL.ai의 last_frame_image_url로 전달된다.
+     * projectId 방식 사용 시 생략 가능 (SceneDto.lastFrameImageUrl 사용).
      */
-    @NotBlank(message = "lastImageId는 필수입니다.")
     private String lastImageId;
 }

--- a/src/main/java/com/estaid/video/dto/VideoResponse.java
+++ b/src/main/java/com/estaid/video/dto/VideoResponse.java
@@ -48,6 +48,14 @@ public class VideoResponse {
      */
     private String videoUrl;
 
+    /**
+     * 영상 썸네일 이미지 URL
+     * Video 엔티티에는 별도 thumbnail 컬럼이 없으므로,
+     * 해당 씬의 첫 프레임 이미지 URL(SceneDto.firstFrameImageUrl)로 대체한다.
+     * null일 수 있음.
+     */
+    private String thumbnail;
+
     /** 영상 길이 (초 단위, null 가능) */
     private Integer duration;
 
@@ -61,12 +69,25 @@ public class VideoResponse {
     private OffsetDateTime createdAt;
 
     /**
-     * {@link Video} 엔티티로부터 응답 DTO를 생성하는 팩토리 메서드
+     * {@link Video} 엔티티로부터 응답 DTO를 생성하는 팩토리 메서드 (thumbnail 없음)
      *
      * @param video Video 엔티티
-     * @return VideoResponse DTO
+     * @return VideoResponse DTO (thumbnail=null)
      */
     public static VideoResponse from(Video video) {
+        return from(video, null);
+    }
+
+    /**
+     * {@link Video} 엔티티 + thumbnail URL로 응답 DTO를 생성하는 팩토리 메서드
+     *
+     * <p>썸네일은 Video 엔티티에 없으므로, 씬의 첫 프레임 이미지 URL을 전달받아 채운다.</p>
+     *
+     * @param video     Video 엔티티
+     * @param thumbnail 썸네일 이미지 URL (null 허용)
+     * @return VideoResponse DTO
+     */
+    public static VideoResponse from(Video video, String thumbnail) {
         return VideoResponse.builder()
                 .videoId(video.getVideoId())
                 .plotId(video.getPlot() != null ? video.getPlot().getPlotId() : null)
@@ -78,6 +99,7 @@ public class VideoResponse {
                 .videoUrl(video.getVideoUrl())
                 .duration(video.getDuration())
                 .status(video.getStatus())
+                .thumbnail(thumbnail)
                 .createdAt(video.getCreatedAt())
                 .build();
     }


### PR DESCRIPTION
# 프론트 수정 요청 — 백엔드 구현 완료 보고서

> 기준 문서: `프론트_수정_요청_구현_플랜.md`
> 구현 완료일: 2026-03-23
> 브랜치: `Dev_CCL`

---

## 전체 구현 현황

| # | 항목 | 상태 | 엔드포인트 |
|---|------|:----:|-----------|
| 1.1 | 자산 통합 생성 (Multipart) | ✅ 완료 | `POST /api/projects/{projectId}/{assetType}` |
| 1.2 | 자산 개별 삭제 | ✅ 완료 | `DELETE /api/projects/{projectId}/{assetType}/{assetId}` |
| 2.1 | AI 스토리보드 생성 | ✅ 완료 | `POST /api/projects/plots/generate` |
| 2.2 | 프레임 재생성 | ✅ 완료 | `POST /api/projects/plots/frames/regenerate` |
| 2.3 | 전체 씬 배치 저장 | ✅ 완료 | `PUT /api/projects/{projectId}/plots/scenes` |
| 3.1 | 영상 페이지 초기 정보 | ✅ 완료 | `GET /projects/{id}/video-info` |
| 3.2 | 영상 생성 API 수정 | ✅ 완료 | `POST /api/videos/generate` (기존 확장) |
| 3.3 | 영상 병합 | ❌ 미구현 | — (구현 복잡도 높음, 별도 협의 필요) |
| 4.1 | 프로젝트 상세 응답 수정 | ✅ 완료 | `GET /projects/{id}` (기존 확장) |

---

## 상세 구현 내용

---

### 1.1 자산 통합 생성 — `POST /api/projects/{projectId}/{assetType}`

**배경**: 기존 2단계 방식(이미지 임시 생성 → 저장)을 1단계로 통합. Multipart/FormData로 이미지 파일을 직접 수신.

#### 신규/수정 파일

| 파일 | 구분 | 변경 내용 |
|------|:----:|-----------|
| `asset/dto/AssetCreateResponse.java` | **신규** | 응답 DTO: id, name, referenceImageUrl, imageUrl, status |
| `asset/AssetService.java` | 수정 | `createAsset()`, `buildAssetPrompt()` 메서드 추가; StorageService·CharacterService·BackgroundService 의존성 추가 |
| `asset/AssetController.java` | 수정 | Multipart POST 엔드포인트 추가 |
| `character/CharacterService.java` | 수정 | `createRaw(projectId, name, referenceImageUrl, artStyle)` 추가 — AssetService에서 호출 |
| `background/BackgroundService.java` | **신규** | `create()`, `delete()` 메서드 (패키지 `com.estaid.background`) |
| `content/entity/BackgroundEntity.java` | 수정 | `@Builder`, `@GeneratedValue`, `@PrePersist`, `@PreUpdate` 추가 |
| `content/repository/BackgroundRepository.java` | 수정 | `findByProjectId()` 메서드 추가 |

#### 처리 흐름

```
1. referenceImage (MultipartFile)
        ↓
2. StorageService.uploadImage(file)
   → Supabase Storage 업로드 → referenceImageUrl 획득
        ↓
3. buildAssetPrompt(name, assetType, style, ratio, quality)
   → FAL.ai 프롬프트 자동 생성
        ↓
4. FalAiService.generateImageSync(referenceImageUrl, prompt)
   → FAL.ai FLUX Kontext 동기 호출 → aiImageUrl 획득
        ↓
    
5. assetType 분기
   ├── "characters"  → CharacterService.createRaw() → CharacterEntity 저장
   └── "backgrounds" → BackgroundService.create()   → BackgroundEntity 저장
        ↓
6. Asset 엔티티 저장 (AI 이미지 URL + 타입)
        ↓
7. { id, name, referenceImageUrl, imageUrl, status: "COMPLETED" } 반환
```

#### Request (Multipart/FormData)

| 필드 | 타입 | 필수 | 설명 |
|------|------|:----:|------|
| `name` | String | ✅ | 자산 이름 |
| `referenceImage` | MultipartFile | ✅ | 참조 이미지 파일 |
| `style` | String | ✅ | REALISTIC / ANIME / 3D / PAINT / SKETCH |
| `ratio` | String | - | 16:9 / 9:16 / 1:1 / 4:3 |
| `quality` | String | - | Standard / High |

#### Response

```json
{
  "id": "uuid",
  "name": "캐릭터명",
  "referenceImageUrl": "https://supabase.../uploads/xxx.jpg",
  "imageUrl": "https://fal.ai/.../generated.jpg",
  "status": "COMPLETED"
}
```

---

### 1.2 자산 개별 삭제 — `DELETE /api/projects/{projectId}/{assetType}/{assetId}`

#### 신규/수정 파일

| 파일 | 구분 | 변경 내용 |
|------|:----:|-----------|
| `asset/AssetService.java` | 수정 | `deleteAsset(projectId, assetType, assetId)` 추가 |
| `asset/AssetController.java` | 수정 | DELETE 엔드포인트 추가 |

#### 처리 흐름

```
assetType = "characters"  → CharacterService.delete(assetId)
assetType = "backgrounds" → BackgroundService.delete(assetId)
```

- 잘못된 assetType: `400 Bad Request`
- 존재하지 않는 assetId: `404 Not Found`
- 성공: `200 OK`

---

### 2.1 AI 스토리보드 자동 생성 — `POST /api/projects/plots/generate`

**배경**: 기존 `POST /api/plots`에서 엔드포인트·필드·프롬프트 전체 변경. 한 프로젝트당 1회 제한.

#### 신규/수정 파일

| 파일 | 구분 | 변경 내용 |
|------|:----:|-----------|
| `plot/dto/PlotGenerateRequest.java` | **신규** | 요청 DTO: projectId, storyDescription, sceneCount, ratio |
| `plot/dto/SceneDto.java` | 수정 | `backgroundDetail`, `majorStory`, `firstFrameImageUrl`, `lastFrameImageUrl` 추가 |
| `plot/PlotController.java` | 수정 | 신규 엔드포인트 추가, 기존 API 하위 호환 유지 |
| `plot/PlotService.java` | 수정 | `generate()` 추가 (1회 제한 로직 포함) |
| `common/service/ClaudeService.java` | 수정 | 프롬프트 수정: composition Enum 10가지 강제, majorStory, backgroundDetail 추가 |

#### Request

```json
{
  "projectId": "uuid",
  "storyDescription": "전체 줄거리 텍스트",
  "sceneCount": 4,
  "ratio": "16:9"
}
```

#### Response (SceneDto 주요 필드)

```json
{
  "sceneNumber": 1,
  "title": "숲속의 조우",
  "composition": "WIDE_SHOT",
  "background": "어두운 숲",
  "backgroundDetail": "Dense pine forest with moonlight filtering through the mist",
  "lighting": "Cinematic moonlight, cold blue tone",
  "majorStory": "주인공이 숲속에서 낯선 그림자와 마주친다.",
  "firstFramePrompt": "...(영어 프롬프트)...",
  "firstFrameImageUrl": null,
  "lastFramePrompt": "...(영어 프롬프트)...",
  "lastFrameImageUrl": null
}
```

> **주의**: `firstFrameImageUrl` / `lastFrameImageUrl`은 생성 직후 `null`. `2.2 프레임 재생성 API`로 개별 생성.

#### composition 허용값 (10가지)

`EXTREME_CLOSEUP` / `HIGH_ANGLE` / `LOW_ANGLE` / `MEDIUM_SHOT` / `OVER_THE_SHOULDER` /
`TWO_SHOT` / `WIDE_SHOT` / `BIRD_EYE_VIEW` / `CLOSEUP` / `DUTCH_ANGLE`

---

### 2.2 프레임 이미지 재생성 — `POST /api/projects/plots/frames/regenerate`

#### 신규/수정 파일

| 파일 | 구분 | 변경 내용 |
|------|:----:|-----------|
| `plot/dto/FrameRegenerateRequest.java` | **신규** | 요청 DTO: projectId, sceneNumber, firstOrLast, prompt |
| `plot/dto/FrameRegenerateResponse.java` | **신규** | 응답 DTO: imageUrl |
| `plot/PlotController.java` | 수정 | 엔드포인트 추가 |
| `plot/PlotService.java` | 수정 | `regenerateFrame()` 추가 |

#### Request / Response

```json
// Request
{
  "projectId": "uuid",
  "sceneNumber": 1,
  "firstOrLast": "FIRST",
  "prompt": "수정된 영어 프롬프트"
}

// Response
{
  "imageUrl": "https://fal.ai/.../generated.jpg"
}
```

#### 처리 흐름

```
1. projectId → Plot 조회
2. sceneNumber로 SceneDto 추출
3. FalAiService.generateImageSync(null, prompt) → 새 이미지 URL 생성
4. SceneDto.firstFrameImageUrl 또는 lastFrameImageUrl 업데이트
5. scenesJson 재직렬화 → Plot DB 저장
6. imageUrl 반환
```

---

### 2.3 전체 씬 배치 저장 — `PUT /api/projects/{projectId}/plots/scenes`

**배경**: 씬 만들기 페이지에서 "다음" 버튼 클릭 시 전체 씬을 한 번에 저장.

#### 신규/수정 파일

| 파일 | 구분 | 변경 내용 |
|------|:----:|-----------|
| `plot/dto/SceneBatchSaveRequest.java` | **신규** | 요청 DTO: `List<SceneDto> scenes` |
| `plot/PlotController.java` | 수정 | 엔드포인트 추가 |
| `plot/PlotService.java` | 수정 | `saveScenesBatch()` 추가 |

#### Request

```json
{
  "scenes": [
    {
      "sceneNumber": 1,
      "title": "숲속의 조우",
      "composition": "WIDE_SHOT",
      "majorStory": "주인공이 그림자와 마주친다.",
      "firstFrameImageUrl": "https://...",
      "lastFrameImageUrl": "https://..."
    }
  ]
}
```

- 기존 `scenesJson`을 요청 데이터로 **완전 교체**
- 성공: `200 OK` (body 없음)

---

### 3.1 영상 페이지 초기 정보 — `GET /projects/{id}/video-info`

**배경**: 영상 생성 페이지 진입 시 씬별 프레임 URL과 통합 프롬프트를 한 번에 제공.

#### 신규/수정 파일

| 파일 | 구분 | 변경 내용 |
|------|:----:|-----------|
| `content/dto/VideoSceneInfoResponse.java` | **신규** | 씬별 정보 record: sceneNumber, title, firstFrameUrl, lastFrameUrl, combinedPrompt |
| `content/dto/VideoPageInitResponse.java` | **신규** | 최상위 응답 record: projectId, scenes |
| `content/service/ContentQueryService.java` | 수정 | `getVideoPageInfo()`, `parseScenes()`, `buildCombinedPrompt()` 추가; ObjectMapper·AssetRepository 주입 |
| `content/controller/ProjectQueryController.java` | 수정 | 엔드포인트 추가 |

#### Response

```json
{
  "projectId": "uuid",
  "scenes": [
    {
      "sceneNumber": 1,
      "title": "숲속의 조우",
      "firstFrameUrl": "https://...",
      "lastFrameUrl": "https://...",
      "combinedPrompt": "A slow cinematic dolly-in through a dark forest..."
    }
  ]
}
```

#### 데이터 탐색 우선순위

| 필드 | 1순위 | 2순위 (폴백) |
|------|-------|------------|
| `firstFrameUrl` | `SceneDto.firstFrameImageUrl` | Image 테이블 FIRST 프레임 |
| `lastFrameUrl` | `SceneDto.lastFrameImageUrl` | Image 테이블 LAST 프레임 |
| `combinedPrompt` | `Video.videoPrompt` (기존 영상 있을 때) | `firstFramePrompt + " " + lastFramePrompt` |

---

### 3.2 영상 생성 API 수정 — `POST /api/videos/generate`

**배경**: 기존 `plotId` + `firstImageId` + `lastImageId` 방식 외에 `projectId` + `sceneNumber` + `prompt` 신규 방식 추가.

#### 신규/수정 파일

| 파일 | 구분 | 변경 내용 |
|------|:----:|-----------|
| `video/dto/VideoGenerateRequest.java` | 수정 | `projectId`, `prompt` 필드 추가; 기존 필드 optional로 변경 |
| `video/dto/VideoResponse.java` | 수정 | `thumbnail` 필드 추가; `from(video, thumbnail)` 오버로드 추가 |
| `video/VideoService.java` | 수정 | projectId 기반 플롯 조회, 사용자 프롬프트 우선 사용, SceneDto URL 사용 로직 추가; `getMainStory()` → `getMajorStory()` 버그 수정 |

#### 방식 A (신규 — projectId 기반)

```json
// Request
{
  "projectId": "uuid",
  "sceneNumber": 1,
  "prompt": "A slow cinematic dolly-in through a dark forest..."
}

// Response (추가된 필드)
{
  "videoId": "uuid",
  "status": "PENDING",
  "thumbnail": "https://... (첫 프레임 이미지 URL)",
  ...
}
```

- `projectId` → 해당 프로젝트의 첫 번째 플롯 자동 조회
- `SceneDto.firstFrameImageUrl` / `lastFrameImageUrl` → FAL.ai 입력 이미지로 사용
- `prompt` → Claude 자동 생성 없이 직접 사용
- `thumbnail` = `firstFrameImageUrl` (Video 엔티티에 별도 컬럼 없음)

#### 방식 B (기존 — plotId 기반, 하위 호환)

```json
{
  "plotId": "uuid",
  "sceneNumber": 1,
  "firstImageId": "uuid",
  "lastImageId": "uuid"
}
```

- Image 엔티티 직접 참조 (기존 방식 유지)
- Claude API로 영상 프롬프트 자동 생성

---

### 4.1 프로젝트 상세 응답 수정 — `GET /projects/{id}`

**배경**: 씬에 title·thumbnail 추가, 에셋(캐릭터·배경 이미지) 목록 추가.

#### 신규/수정 파일

| 파일 | 구분 | 변경 내용 |
|------|:----:|-----------|
| `content/dto/AssetItemResponse.java` | **신규** | 에셋 요약 record: assetId, type, imageUrl, prompt |
| `content/dto/ProjectSceneDetailResponse.java` | 수정 | `sceneTitle`, `thumbnail` 필드 추가 |
| `content/dto/ProjectDetailResponse.java` | 수정 | `List<AssetItemResponse> assets` 필드 추가 |
| `content/service/ContentQueryService.java` | 수정 | `getProjectDetail()` — sceneTitle, thumbnail, assets 조회 로직 추가 |

#### Response (변경된 부분)

```json
{
  "projectId": "uuid",
  "title": "내 작품",
  "scenes": [
    {
      "plotId": "uuid",
      "plotTitle": "플롯 제목",
      "sceneNumber": 1,
      "sceneTitle": "숲속의 조우",        ← 신규
      "thumbnail": "https://...",         ← 신규
      "images": [...],
      "video": {...}
    }
  ],
  "assets": [                             ← 신규
    {
      "assetId": "uuid",
      "type": "CHARACTER",
      "imageUrl": "https://...",
      "prompt": "character portrait of..."
    }
  ]
}
```

#### thumbnail 탐색 우선순위

1. `SceneDto.firstFrameImageUrl` (scenesJson에서 파싱)
2. Image 테이블의 `frameType = "FIRST"` 이미지 URL
3. 없으면 `null`

---

## 기존 API 하위 호환 유지 목록

변경하지 않은 기존 API — 기존 프론트엔드 코드가 그대로 동작한다.

| 엔드포인트 | 설명 |
|-----------|------|
| `POST /api/plots` | 플롯 생성 (구 방식) |
| `GET /api/plots?projectId={id}` | 플롯 목록 조회 |
| `GET /api/plots/{plotId}` | 플롯 단건 조회 |
| `PUT /api/plots/{plotId}/scenes/{sceneNumber}` | 씬 단건 수정 |
| `DELETE /api/plots/{plotId}` | 플롯 삭제 |
| `POST /api/characters/generate` | 캐릭터 이미지 임시 생성 |
| `POST /api/backgrounds/generate` | 배경 이미지 임시 생성 |
| `POST /api/projects/{projectId}/assets` | 자산 확정 저장 |
| `GET /api/projects/{projectId}/assets` | 자산 목록 조회 |
| `POST /api/videos/generate` | 영상 생성 (방식 B 유지) |

---

## DB 변경 사항

**DDL 변경 없음** — `schema.sql` 수정하지 않음.

| 테이블 | 변경 여부 | 비고 |
|--------|:--------:|------|
| `characters` | ❌ | 기존 그대로 |
| `backgrounds` | ❌ | 기존 그대로 |
| `assets` | ❌ | 기존 그대로 |
| `plots.scenes_json` | ⚠️ 내용 변경 | JSON 컬럼 변경 없음, 저장되는 필드명 변경 (`mainStory` → `majorStory`, `backgroundDetail` 추가 등) |
| `videos` | ❌ | thumbnail은 응답 DTO에서만 처리, 컬럼 추가 없음 |
| `images` | ❌ | 기존 그대로 |

---

## 프론트 협의 필요 사항

| 항목 | 내용 |
|------|------|
| `firstFrameImageUrl` / `lastFrameImageUrl` | 플롯 생성 직후 `null` 반환 → `POST /api/projects/plots/frames/regenerate`로 개별 생성 |
| 영상 생성 동기/비동기 | FAL.ai 영상 생성은 수분 소요 → PENDING 즉시 반환 후 폴링(`GET /api/videos/{videoId}`) |
| thumbnail | Video 엔티티에 별도 컬럼 없음 → `firstFrameImageUrl`로 대체하여 응답에 포함 |
| 병합 (3.3) | 구현 복잡도 높아 미구현 — FFmpeg or 외부 API 별도 협의 필요 |
